### PR TITLE
semgrep 1.70.0: Set the path to libev for static linking

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -792,6 +792,7 @@ git-codereview
 git-cola
 git-credential-oauth
 git-delta
+git-extras
 git-grab
 git-lfs
 git-split-diffs

--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1665,6 +1665,9 @@ pyinstaller
 pylint
 pymol
 pyoxidizer
+pypy
+pypy3.10
+pypy3.9
 pyqt-builder
 pyright
 pyside@2

--- a/Formula/a/allure.rb
+++ b/Formula/a/allure.rb
@@ -11,7 +11,7 @@ class Allure < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "51bc8bf5e3321f386e64b35d640fd7a1853916ab75fb6a8a53be6eb4c71856c4"
+    sha256 cellar: :any_skip_relocation, all: "c86a7ce74feb18ce05dd5133d09958cfbe3ccaa079d0fe9fb312741d25779526"
   end
 
   depends_on "openjdk"

--- a/Formula/a/allure.rb
+++ b/Formula/a/allure.rb
@@ -1,8 +1,8 @@
 class Allure < Formula
   desc "Flexible lightweight test report tool"
   homepage "https://github.com/allure-framework/allure2"
-  url "https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.28.0/allure-commandline-2.28.0.zip"
-  sha256 "a72e4676b74c83406fe9a0a897c037dc86035157bda6af37982a8f700034f7c7"
+  url "https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.29.0/allure-commandline-2.29.0.zip"
+  sha256 "0b1d1144c699724cdfec769efad457475d8039718edfe7b1439acbd317c14223"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/a/apache-arrow.rb
+++ b/Formula/a/apache-arrow.rb
@@ -5,7 +5,7 @@ class ApacheArrow < Formula
   mirror "https://archive.apache.org/dist/arrow/arrow-15.0.2/apache-arrow-15.0.2.tar.gz"
   sha256 "abbf97176db6a9e8186fe005e93320dac27c64562755c77de50a882eb6179ac6"
   license "Apache-2.0"
-  revision 2
+  revision 3
   head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do

--- a/Formula/a/apache-arrow.rb
+++ b/Formula/a/apache-arrow.rb
@@ -9,13 +9,13 @@ class ApacheArrow < Formula
   head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "6af487e2c04f55015dd3275cdc89b57fe843afd2721bf0735272fef91e85c6f1"
-    sha256 cellar: :any, arm64_ventura:  "eb183e1a97988fe4f095ae8dabd6bb8a657249e36ab6b9478255bbd7a95567b8"
-    sha256 cellar: :any, arm64_monterey: "4d9108c2c3d2ad54ef9fb12acab525f0bae7674b09b2c4cfc360e093e8ef329e"
-    sha256 cellar: :any, sonoma:         "e1254f7fb473eecbf67b8ef8fb6197725f6ed6dfb9e7ced08030db0d5c8cac2e"
-    sha256 cellar: :any, ventura:        "311c9b58c7416517f5a7f2a05b418a71e6e1566d4c5d1d6690dbc875e364fa92"
-    sha256 cellar: :any, monterey:       "83cd9dd8d9e19ec13e50973e68cbaca9ed6e34b4ba39a55b5f4c1eb7ee70c030"
-    sha256               x86_64_linux:   "e2b4742219a35a41cd51c270c6036f2e6c89f80a6ec230e4a621444544a7f930"
+    sha256 cellar: :any, arm64_sonoma:   "744efe8f7602b219e974ec89f028b2d96522915ba30c859572aacaef9f1a72d0"
+    sha256 cellar: :any, arm64_ventura:  "e0f9cd1a7fe97e0972188c3ea967b65bba4545220d5cdf08cc52edd2e610eed0"
+    sha256 cellar: :any, arm64_monterey: "d93573b391d94d6287bc6cda94f641ebed61e1e13431c0703a6f44f5a8e3b17f"
+    sha256 cellar: :any, sonoma:         "fbad317cc877b7f3572a563d0591c395230d739c4239e51fc29e173ffba376db"
+    sha256 cellar: :any, ventura:        "effe7f0860daabf8bc4e3d557415732865fde2d341ffe85fea64531e22c33ca2"
+    sha256 cellar: :any, monterey:       "68e33a1da68ad277855ccb530e3cec0e0b1e90e9b4bf93c9da207d0c9bce048c"
+    sha256               x86_64_linux:   "1e474abf4a4d4cea7c9f8a6f599e836c3c0f7d9bafa86f8b9e2e28aeac91b91b"
   end
 
   depends_on "boost" => :build

--- a/Formula/a/apache-pulsar.rb
+++ b/Formula/a/apache-pulsar.rb
@@ -5,6 +5,7 @@ class ApachePulsar < Formula
   mirror "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/apache-pulsar-3.1.2-src.tar.gz"
   sha256 "82270fa4c224af7979d6d4689d7a77742eb3a32a32630e052dc93739a35624e2"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/pulsar.git", branch: "master"
 
   bottle do

--- a/Formula/a/apache-pulsar.rb
+++ b/Formula/a/apache-pulsar.rb
@@ -9,10 +9,10 @@ class ApachePulsar < Formula
   head "https://github.com/apache/pulsar.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, sonoma:       "1422e2ca66e52531d8d6757307e1d051a5a613424380b8f2cc5c2cbc8112d90f"
-    sha256 cellar: :any_skip_relocation, ventura:      "db3d30e2d84ccb55eddfdd8989dee651e37bbde90d18491e68d5ca2f7e98ea3a"
-    sha256 cellar: :any_skip_relocation, monterey:     "358819b26436b5b5d949a93c5a48644bf90483d6b53e56ab410ea6bba35ebd67"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1c9adade12d3e3364db1b3f7c1823766845e59ee84f98aa2b78214870c8d4c1c"
+    sha256 cellar: :any_skip_relocation, sonoma:       "84d3eaf420f61cf8d8c1f51dbdc1ad6fcacb1b1631dd22b241ced620b2fa4f91"
+    sha256 cellar: :any_skip_relocation, ventura:      "eaca256d0c8f8152e8696142aae0d0aed390adb7ecb7349e2d61c228c38f4f07"
+    sha256 cellar: :any_skip_relocation, monterey:     "b01912fe86d28f7c4be6d79134b80d93829ac0e172e9743f4c96ad1d3ddc4028"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "3d0a75a7e0c5167a2407a0a20b090eb6859e44374a95ec4c41a468e6627b2a70"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/a/astyle.rb
+++ b/Formula/a/astyle.rb
@@ -1,8 +1,8 @@
 class Astyle < Formula
   desc "Source code beautifier for C, C++, C#, and Java"
   homepage "https://astyle.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/astyle/astyle/astyle%203.4/astyle-3.4.13.tar.bz2"
-  sha256 "78a610abd39e94e0f913e9ee5cda1e85bb62cd633553decb9e00d3d9201019ce"
+  url "https://downloads.sourceforge.net/project/astyle/astyle/astyle%203.4/astyle-3.4.14.tar.bz2"
+  sha256 "606a83f39146733185f6763059d292433c40f393eb6f52042e163f8df4e16a3e"
   license "MIT"
   head "https://svn.code.sf.net/p/astyle/code/trunk/AStyle"
 
@@ -21,11 +21,13 @@ class Astyle < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d9407606901842fcbc5ed0853a3ea7c352bbc288a3eee4dcc960516e40fae8b"
   end
 
+  depends_on "cmake" => :build
+
   def install
-    cd "src" do
-      system "make", "CXX=#{ENV.cxx}", "-f", "../build/gcc/Makefile"
-      bin.install "bin/astyle"
-    end
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    man1.install "man/astyle.1"
   end
 
   test do

--- a/Formula/a/astyle.rb
+++ b/Formula/a/astyle.rb
@@ -12,13 +12,13 @@ class Astyle < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f8752a9e563685ba70cfa94b692b0e6b312b8f31586927442ed52b39ab375d7c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "168d3a591b56816d6b07fd77caf153e1c50249f66f622c1f29cc741b553934ad"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "76a699d10c2b3ba613f32a78c335a7226239033ce58b72269d10d784defed2f0"
-    sha256 cellar: :any_skip_relocation, sonoma:         "cd4f277b2fc5ef4b56e7f092a9bdda987d21bb5dc666484c52493a9d5aef6a7f"
-    sha256 cellar: :any_skip_relocation, ventura:        "719e8b8c846f17e285593336979cf177a9b392cc8104aa3c055c21cddcf5ae64"
-    sha256 cellar: :any_skip_relocation, monterey:       "01aef09fef4c53619c12b6ccb517ea72e15e1ddb64bd054ea0626052134e953c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d9407606901842fcbc5ed0853a3ea7c352bbc288a3eee4dcc960516e40fae8b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e1f6d79cb1cdc6af7c6df8f7aadbe9c6793b61c5b4172817a6c6f58e28bf42ff"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d9f46ba46d47b9f3534554cda6d07725cab54b65143d632c3608e06649648e54"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "a4850a7e8d0f9894087893153528bcc80258f8cceb4131cb3156030ab9c94d0c"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c8802d27b7a53a488912ea6697bec11931e6b9606b1a508275da4ffbffd5272a"
+    sha256 cellar: :any_skip_relocation, ventura:        "907dfefce040a024533e60f5a3ccb87a8b3d3f648da0692e40ed23ee501ad532"
+    sha256 cellar: :any_skip_relocation, monterey:       "b440b0ae21e0cf7f8a61d8b25594e988f5804be7df60db381f498570959735a5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2ba73cbd773ae8bfd0724850a90606efe8f190b09fb75afabacc5abc01388408"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/awscli.rb
+++ b/Formula/a/awscli.rb
@@ -137,10 +137,7 @@ class Awscli < Formula
     ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
 
     # The `awscrt` resource requires `setuptools` & `wheel`, so they must be installed first
-    venv = virtualenv_create(libexec, "python3.11", system_site_packages: false)
-    venv.pip_install resources.reject { |r| r.name == "awscrt" }
-    venv.pip_install resource("awscrt")
-    venv.pip_install_and_link buildpath
+    virtualenv_install_with_resources(system_site_packages: false, end_with: "awscrt")
 
     pkgshare.install "awscli/examples"
 

--- a/Formula/a/azion.rb
+++ b/Formula/a/azion.rb
@@ -1,8 +1,8 @@
 class Azion < Formula
   desc "CLI for the Azion service"
   homepage "https://github.com/aziontech/azion"
-  url "https://github.com/aziontech/azion/archive/refs/tags/1.19.1.tar.gz"
-  sha256 "0a6c84ba421b16ce4c98521d17b6b63689d3d16cd2d6e379574a10cf01e0f9dd"
+  url "https://github.com/aziontech/azion/archive/refs/tags/1.20.0.tar.gz"
+  sha256 "b95db9ef531d4def43b1f3cf862fb0fd69d2fe881ed78366f4a3a7fbd1944af3"
   license "MIT"
 
   bottle do

--- a/Formula/a/azion.rb
+++ b/Formula/a/azion.rb
@@ -6,13 +6,13 @@ class Azion < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cbd8e1a42324d7c943e9b2d8c2d20899da574917bbbab5f2b5919808698d5205"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b2b74cb283218887d69725f017de7472c849061f1e5db10abcb992138ff39e21"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "204836fdc659eea7a3a54e18d3a70600ae9a3bc9d4d3933682d696880acb05b4"
-    sha256 cellar: :any_skip_relocation, sonoma:         "eb78a4c9c6d22dc071ccd1cc3fb696b23f62aa18fe487734161068419bc420f7"
-    sha256 cellar: :any_skip_relocation, ventura:        "cb167a37945190a5e7fe1f23668232887fa0390759fa82f33fab127ac727ec29"
-    sha256 cellar: :any_skip_relocation, monterey:       "7bae52f7151032de518f1f1a1edf2ed1863e293ef37a00a471e3759511d231ac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "364406eb185a071c9f5f7a0ad6c9bb64a64f9a3acf66f01109c5d7c6b0920480"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8b6e01e223ba8d5639c1929d6a0fe733da1c2d7692e829852de6c3e416681b2b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0ca17dbf677f8f5d17dfe5f637c3dec90da164dd0130501b0b6fd6094a6a58f1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9b7ed6e9ce375226c0893b1c3856a15cc4efda49c3fde5e41289298e00f15fb1"
+    sha256 cellar: :any_skip_relocation, sonoma:         "8cd42ecd342755b2b9e2e2f51b995d59ae6c4e8c32e398d0025af51be292ee95"
+    sha256 cellar: :any_skip_relocation, ventura:        "1e7d3a12fe4ea85291b86be6f104672b5b612a5ad2569fc10c63d274b087e5fb"
+    sha256 cellar: :any_skip_relocation, monterey:       "ab42ba8042ed7a5aca6622c2321d3ce79412d42acb91d8a816dec3e913ada01f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "606e1471e4fb848e917301bf38f98c0a35f378ffe2a4aaff88eaa1f003b867e8"
   end
 
   depends_on "go" => :build

--- a/Formula/b/black.rb
+++ b/Formula/b/black.rb
@@ -14,13 +14,13 @@ class Black < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "43ad20b7c6c5d5ec45e39b539475d6ee80e59a344533ba760f133a8276a96e39"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0bcf5dc74d5fae7109f564b8d0cbdb4f20136295f929adcc054729a5a03812e8"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c970dc9b7255552dae091ba72f861fed94ee2deec4c9df730fb50da9fce18892"
-    sha256 cellar: :any_skip_relocation, sonoma:         "823a44370eaf05e78b438c2aa135c6bda02a5aec8dba53e6b4da66d6c2ee3bb5"
-    sha256 cellar: :any_skip_relocation, ventura:        "eabeb77eef8f212f9aa1e7a436bc3768c18e253eb1688c5de0f7cb9dadf0b854"
-    sha256 cellar: :any_skip_relocation, monterey:       "72ba8d31c55ceaddc21648acf2ca635cb6af8285dc3dadb5de684bff17bf87fa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b4f56894d076553242648edae23f9c2a08bc08f79bb64d3d5dbe8715147054dd"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "aff695fdca09652c16de45b73c899c064030578c4068c8aeebc58d4561e6375d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cef8589f708ded35e11e33a3ed6a2ac18dbcafb3e48e4e7c7ac4bc39b0a92401"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9ccac57d5ce0911ba219ca631932185d2bacbce0b3e8fcd504c7dd504891cdb5"
+    sha256 cellar: :any_skip_relocation, sonoma:         "ea5c8bdb58628902023c4bb6eecb9cb77b914bf08ab0384762dd248c540d9c1f"
+    sha256 cellar: :any_skip_relocation, ventura:        "bc74246f60bdd5c3353e599cbe5380ebb914127c7107dc27a2df52334f65849e"
+    sha256 cellar: :any_skip_relocation, monterey:       "5702af46fa4540e152a6b6fe445da9e78f5a6a6eb78c3e8790cbdc923043c789"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ea4153040e368c55bbe1f8815d01be4a04966dd57faef68c7e18c6d28b3a239"
   end
 
   depends_on "python@3.12"

--- a/Formula/b/black.rb
+++ b/Formula/b/black.rb
@@ -3,8 +3,8 @@ class Black < Formula
 
   desc "Python code formatter"
   homepage "https://black.readthedocs.io/en/stable/"
-  url "https://files.pythonhosted.org/packages/e7/29/58e93d7775544b6058f1df71dce4a8f5b039c2f8e381d3c695444c3d3d5f/black-24.4.0.tar.gz"
-  sha256 "f07b69fda20578367eaebbd670ff8fc653ab181e1ff95d84497f9fa20e7d0641"
+  url "https://files.pythonhosted.org/packages/57/13/4075f1b5b394e4ccd7fccf6646957e6b454260a0a89b2093fa1b60dc6de6/black-24.4.1.tar.gz"
+  sha256 "5241612dc8cad5b6fd47432b8bd04db80e07cfbc53bb69e9ae18985063bcb8dd"
   license "MIT"
   head "https://github.com/psf/black.git", branch: "main"
 
@@ -26,8 +26,8 @@ class Black < Formula
   depends_on "python@3.12"
 
   resource "aiohttp" do
-    url "https://files.pythonhosted.org/packages/7e/0b/4235b25496c741f4c9f75a94951fbc15c48537349a03448687fb226256ef/aiohttp-3.9.4.tar.gz"
-    sha256 "6ff71ede6d9a5a58cfb7b6fffc83ab5d4a63138276c771ac91ceaaddf5459644"
+    url "https://files.pythonhosted.org/packages/04/a4/e3679773ea7eb5b37a2c998e25b017cc5349edf6ba2739d1f32855cfb11b/aiohttp-3.9.5.tar.gz"
+    sha256 "edea7d15772ceeb29db4aff55e482d4bcfb6ae160ce144f2682de02f6d693551"
   end
 
   resource "aiosignal" do
@@ -76,8 +76,8 @@ class Black < Formula
   end
 
   resource "platformdirs" do
-    url "https://files.pythonhosted.org/packages/96/dc/c1d911bf5bb0fdc58cc05010e9f3efe3b67970cef779ba7fbc3183b987a8/platformdirs-4.2.0.tar.gz"
-    sha256 "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+    url "https://files.pythonhosted.org/packages/b2/e4/2856bf61e54d7e3a03dd00d0c1b5fa86e6081e8f262eb91befbe64d20937/platformdirs-4.2.1.tar.gz"
+    sha256 "031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf"
   end
 
   resource "yarl" do

--- a/Formula/b/bzt.rb
+++ b/Formula/b/bzt.rb
@@ -253,18 +253,15 @@ class Bzt < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.12")
+    venv = virtualenv_install_with_resources without: "terminaltables"
 
     # Switch build-system to poetry-core to avoid rust dependency on Linux.
     # Remove when released: https://github.com/matthewdeanmartin/terminaltables/pull/1
     resource("terminaltables").stage do
       inreplace "pyproject.toml", 'requires = ["poetry>=0.12"]', 'requires = ["poetry-core>=1.0"]'
       inreplace "pyproject.toml", 'build-backend = "poetry.masonry.api"', 'build-backend = "poetry.core.masonry.api"'
-      venv.pip_install_and_link Pathname.pwd
+      venv.pip_install Pathname.pwd
     end
-
-    venv.pip_install resources.reject { |r| r.name == "terminaltables" }
-    venv.pip_install_and_link buildpath
   end
 
   test do

--- a/Formula/c/cloudflare-wrangler2.rb
+++ b/Formula/c/cloudflare-wrangler2.rb
@@ -5,8 +5,8 @@ class CloudflareWrangler2 < Formula
 
   desc "CLI tool for Cloudflare Workers"
   homepage "https://github.com/cloudflare/workers-sdk"
-  url "https://registry.npmjs.org/wrangler/-/wrangler-3.51.2.tgz"
-  sha256 "cb2db58b73368aec7e5ecc023689b42064432f3631fa82df1305b53ce2d63af2"
+  url "https://registry.npmjs.org/wrangler/-/wrangler-3.52.0.tgz"
+  sha256 "ecdd056ae97c5c68d259bc865f01528007bc2b7a5b62e02e49e63a4dfb25bcbd"
   license any_of: ["Apache-2.0", "MIT"]
 
   bottle do

--- a/Formula/c/cloudflare-wrangler2.rb
+++ b/Formula/c/cloudflare-wrangler2.rb
@@ -10,13 +10,13 @@ class CloudflareWrangler2 < Formula
   license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "aacf00c91ff8df64be3246779c7b2d3fb1ced5a6b21355b20913fa4c6189a6c8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "aacf00c91ff8df64be3246779c7b2d3fb1ced5a6b21355b20913fa4c6189a6c8"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "aacf00c91ff8df64be3246779c7b2d3fb1ced5a6b21355b20913fa4c6189a6c8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "80339935af0ddaadf670506b240b382bd17c4e7cd195722b2bb97a54c2c3520a"
-    sha256 cellar: :any_skip_relocation, ventura:        "80339935af0ddaadf670506b240b382bd17c4e7cd195722b2bb97a54c2c3520a"
-    sha256 cellar: :any_skip_relocation, monterey:       "80339935af0ddaadf670506b240b382bd17c4e7cd195722b2bb97a54c2c3520a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1197f874d78c2e4377b54d61a1658ac0b8775c8b0308226caf8302254ed827a1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b175d62d1b5d64cd9bde4f82e5231934ff0508f28344ba89d5d42a24b34679e7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b175d62d1b5d64cd9bde4f82e5231934ff0508f28344ba89d5d42a24b34679e7"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b175d62d1b5d64cd9bde4f82e5231934ff0508f28344ba89d5d42a24b34679e7"
+    sha256 cellar: :any_skip_relocation, sonoma:         "4e6fc016788361fb9cf1d6ff5600c5695cd2bc6295bbe5228d8c2e8c9ac20f3e"
+    sha256 cellar: :any_skip_relocation, ventura:        "4e6fc016788361fb9cf1d6ff5600c5695cd2bc6295bbe5228d8c2e8c9ac20f3e"
+    sha256 cellar: :any_skip_relocation, monterey:       "4e6fc016788361fb9cf1d6ff5600c5695cd2bc6295bbe5228d8c2e8c9ac20f3e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "51f8c8d250fdcc41847d2527d6d89144c1a17380998c9a1da3e93b745406e192"
   end
 
   depends_on "node"

--- a/Formula/d/dissent.rb
+++ b/Formula/d/dissent.rb
@@ -1,8 +1,8 @@
 class Dissent < Formula
   desc "GTK4 Discord client in Go"
   homepage "https://github.com/diamondburned/dissent"
-  url "https://github.com/diamondburned/dissent/archive/refs/tags/v0.0.23.tar.gz"
-  sha256 "7c5e10a6111cd8912c052337c56cb04cbb92b237453d560c85409f1c8f8cc01b"
+  url "https://github.com/diamondburned/dissent/archive/refs/tags/v0.0.24.tar.gz"
+  sha256 "65537bbc947acfc53fdd7bf0ab98e083fb78af73507b27deec9ba92c1bc783cc"
   license "GPL-3.0-or-later"
   head "https://github.com/diamondburned/dissent.git", branch: "main"
 

--- a/Formula/d/dissent.rb
+++ b/Formula/d/dissent.rb
@@ -7,13 +7,13 @@ class Dissent < Formula
   head "https://github.com/diamondburned/dissent.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "447bf4a3f5a064df2f4e5c0c0c3131fe6212c0978e06741809b18853921810c3"
-    sha256 cellar: :any,                 arm64_ventura:  "d18368812743ff9e7cc21b561aa137c0698a96bd76e4aaadc6bbd4bc1178ceb4"
-    sha256 cellar: :any,                 arm64_monterey: "3813049fcbfa8b14054700fa1608882118c7083264dacd3d7673e7e67fc0cfde"
-    sha256 cellar: :any,                 sonoma:         "68fb1c64b89c9b145a2d322ca70566f777cce85603f4e2c10732afb556dfb059"
-    sha256 cellar: :any,                 ventura:        "39513cbc5a7e853884c1857d1d0b6575717c19c7e3c2b89cd2447858c7bf3038"
-    sha256 cellar: :any,                 monterey:       "f721d3e16f6cd9aca035a6fc01a99bb461a19dbe1a0f3b7b1bb6f2b9a8c0fd38"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "72bbb0fc22aebe42eacdd3ffd8e9a3737fc7268073514e064614e79f90e652b4"
+    sha256 cellar: :any,                 arm64_sonoma:   "c945bf5d945474d36acdf05c6e9ea0584d5c1021b7c22918f278626f1723302e"
+    sha256 cellar: :any,                 arm64_ventura:  "9d18607c8a0ccb1bcc7d5198198266e84863a4d3b36119863e9b4dff9ddbe56e"
+    sha256 cellar: :any,                 arm64_monterey: "0035dab703869173a5ea4b61926d978d50eb852259c1ae7b9ca25496d2603e18"
+    sha256 cellar: :any,                 sonoma:         "a24f1a11ba24ad181ef7a27ecbb4960b8ad7cf836903e9d89d5aada56481105e"
+    sha256 cellar: :any,                 ventura:        "8729e5f9a0d6267f1e15e88737a7226976863ac99d3f3e88566ceb6c0b802290"
+    sha256 cellar: :any,                 monterey:       "0b6992a6cb33163bfcd0e71956b8bc00e87051a7e3f870597d4be2d22ae48c85"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d8d3c45975320f4621985e57b5d891e14ac6be8d823b2c25f06167f47266aaba"
   end
 
   depends_on "go" => :build

--- a/Formula/e/ecflow-ui.rb
+++ b/Formula/e/ecflow-ui.rb
@@ -1,8 +1,8 @@
 class EcflowUi < Formula
   desc "User interface for client/server workflow package"
   homepage "https://confluence.ecmwf.int/display/ECFLOW"
-  url "https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.12.3-Source.tar.gz"
-  sha256 "2caaf64bf1e0ced87fd0bf42c2ee3385093420e5c4609ad4117b8251420d1cf0"
+  url "https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.12.4-Source.tar.gz"
+  sha256 "4ff11e420105ffcff6fa2f9d54682ac9e7f0007b6a7c52d1ce3cd6cd81cebfe5"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/e/ecflow-ui.rb
+++ b/Formula/e/ecflow-ui.rb
@@ -11,13 +11,13 @@ class EcflowUi < Formula
   end
 
   bottle do
-    sha256                               arm64_sonoma:   "2074c4c7fb2d368a77aa9b8d4c3cf21b395dfda837e607d6f4d98c12cb81f6eb"
-    sha256                               arm64_ventura:  "7b863447c992c4871f0eadec65c41181d43ad849f6cb091842e99cc429fc6e2a"
-    sha256                               arm64_monterey: "7fde65f33fceff248db752c81764c7529304ea19440e0265e09a259b5bf41df8"
-    sha256                               sonoma:         "3f4ad5405ee09dd1f0ba153736856a8ca796868f1e34e7bc2e15acdb78be5292"
-    sha256                               ventura:        "340786860a9ef0e1c890cc9c5955c5ebc3f638d7b46bca46a33a0c98557a0ae4"
-    sha256                               monterey:       "5a07cb2ca3db765374513ab5ed27f12ca0fd94bc5b729ef03f43e5acbc24e070"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c61e596c74db0afee3a9ac3ad2a742570086533fb3970787db1f2f7e3a8ceb4f"
+    sha256                               arm64_sonoma:   "5c71db0459761beb117b355596bcb66a345893c2aeeba73886a63a5bbd2cf04f"
+    sha256                               arm64_ventura:  "bdbfe935e374dc09d61dca65993cd5967ec6c7cbf410c0874acf41c70753d777"
+    sha256                               arm64_monterey: "ae039fe42842b6ce5716a1eac670770b3c0c85c95e7c229705f6eb0698d5b3c4"
+    sha256                               sonoma:         "11a6f7822a8508a2a3c9c886c1d4f950f11ec862fb3d684a5ceb0fc0010a7503"
+    sha256                               ventura:        "dd10290cdbdcd97a5fefa09e1617af0da806fa4ad009c20bb673e9fc1e721c71"
+    sha256                               monterey:       "850b7ad610597da55e483dd7783b40d8b72fcb9664583045506a36885ab87635"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cd4766f7d3b50abde37bbe2fcbfb153183737b912b26bcbec4722b5a8842287c"
   end
 
   depends_on "boost" => :build

--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -5,12 +5,9 @@ class Fdroidserver < Formula
   homepage "https://f-droid.org"
   # TODO: Remove `androguard==3.3.5` from pypi_formula_mappings.json in the next release.
   # Ref: https://github.com/f-droid/fdroidserver/commit/2f84ce36da2aa79c1583832cd475b1d0be14cca5
-  # Ensure `sdkmanager` resource is present. It will be grabbed by `pip` starting in the next release.
-  # Ref: https://github.com/f-droid/fdroidserver/commit/0dd5a7db648133e3f5ea2dfe1acc381b0541738b
-  url "https://files.pythonhosted.org/packages/75/72/ea1e1e9d7d0ade051279b8676e6025f8c14dd64a5edeb76f2208e23c7720/fdroidserver-2.2.1.tar.gz"
-  sha256 "6dcba0b747bfc9ebe4d441c56cf0c8aeab70a58cd0d1248462892e933a382302"
+  url "https://files.pythonhosted.org/packages/3c/39/16a78b07797a6fb7fdce85aaa0bb71fb1e459dcdd73ee70be5ff15711059/fdroidserver-2.2.2.tar.gz"
+  sha256 "19c268168fa65ad2be4a4f27f4750b9c9d54ddaa5fab229d4d1770f161a093b2"
   license "AGPL-3.0-or-later"
-  revision 5
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "5a2b65a85e1b1ed2c9f5358165354bba1e289f8d41f61be498b523a6dbad7230"
@@ -51,6 +48,11 @@ class Fdroidserver < Formula
   resource "apache-libcloud" do
     url "https://files.pythonhosted.org/packages/1b/45/1a239d9789c75899df8ff53a6b198c1657328f3b333f1711194643d53868/apache-libcloud-3.8.0.tar.gz"
     sha256 "75bf4c0b123bc225e24ca95fca1c35be30b19e6bb85feea781404d43c4276c91"
+  end
+
+  resource "argcomplete" do
+    url "https://files.pythonhosted.org/packages/79/51/fd6e293a64ab6f8ce1243cf3273ded7c51cbc33ef552dce3582b6a15d587/argcomplete-3.3.0.tar.gz"
+    sha256 "fd03ff4a5b9e6580569d34b273f741e85cd9e072f3feeeee3eba4891c70eda62"
   end
 
   resource "args" do
@@ -158,6 +160,11 @@ class Fdroidserver < Formula
     sha256 "e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec"
   end
 
+  resource "looseversion" do
+    url "https://files.pythonhosted.org/packages/64/7e/f13dc08e0712cc2eac8e56c7909ce2ac280dbffef2ffd87bd5277ce9d58b/looseversion-1.3.0.tar.gz"
+    sha256 "ebde65f3f6bb9531a81016c6fef3eb95a61181adc47b7f949e9c0ea47911669e"
+  end
+
   resource "lxml" do
     url "https://files.pythonhosted.org/packages/ea/e2/3834472e7f18801e67a3cd6f3c203a5456d6f7f903cfb9a990e62098a2f3/lxml-5.2.1.tar.gz"
     sha256 "3f7765e69bbce0906a7c74d5fe46d2c7a7596147318dbc08e4a2431f3060e306"
@@ -169,8 +176,8 @@ class Fdroidserver < Formula
   end
 
   resource "matplotlib-inline" do
-    url "https://files.pythonhosted.org/packages/d9/50/3af8c0362f26108e54d58c7f38784a3bdae6b9a450bab48ee8482d737f44/matplotlib-inline-0.1.6.tar.gz"
-    sha256 "f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"
+    url "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz"
+    sha256 "8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"
   end
 
   resource "networkx" do
@@ -288,9 +295,14 @@ class Fdroidserver < Formula
     sha256 "beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"
   end
 
+  resource "sdkmanager" do
+    url "https://files.pythonhosted.org/packages/c2/d7/5f771226151ff8df1799bb16a3812abb8b8935df71c0af2eb84901600163/sdkmanager-0.6.7.tar.gz"
+    sha256 "b81080462b8fe7eecd6b78f7fb13ead833d64813591ea43b470c523089a3bac7"
+  end
+
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/4d/5b/dc575711b6b8f2f866131a40d053e30e962e633b332acf7cd2c24843d83d/setuptools-69.2.0.tar.gz"
-    sha256 "0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"
+    url "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
+    sha256 "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"
   end
 
   resource "six" do
@@ -309,8 +321,8 @@ class Fdroidserver < Formula
   end
 
   resource "traitlets" do
-    url "https://files.pythonhosted.org/packages/4f/97/d957b3a5f6da825cbbb6a02e584bcab769ea2c2a9ad67a9cc25b4bbafb30/traitlets-5.14.2.tar.gz"
-    sha256 "8cdd83c040dab7d1dee822678e5f5d100b514f7b72b01615b26fc5718916fdf9"
+    url "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz"
+    sha256 "9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"
   end
 
   resource "typing-extensions" do
@@ -319,8 +331,8 @@ class Fdroidserver < Formula
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/7a/50/7fd50a27caa0652cd4caf224aa87741ea41d3265ad13f010886167cfcc79/urllib3-2.2.1.tar.gz"
-    sha256 "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+    url "https://files.pythonhosted.org/packages/0c/39/64487bf07df2ed854cc06078c27c0d0abc59bd27b32232876e403c333a08/urllib3-1.26.18.tar.gz"
+    sha256 "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
   end
 
   resource "wcwidth" do

--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -10,13 +10,13 @@ class Fdroidserver < Formula
   license "AGPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "5a2b65a85e1b1ed2c9f5358165354bba1e289f8d41f61be498b523a6dbad7230"
-    sha256 cellar: :any,                 arm64_ventura:  "e196c607fdb5519417684ebdccb2195ca86c224dcfe184838e8f5d0018a3b57f"
-    sha256 cellar: :any,                 arm64_monterey: "f70c1d5133db7f1fcfe9f6d9368c2a049abbaa215bec6f4cfb795a1cd24e91d9"
-    sha256 cellar: :any,                 sonoma:         "8fb040971f0e04fc78593e8def360341434d061d0d9c4017fb7d344a2f4f1e79"
-    sha256 cellar: :any,                 ventura:        "882dba5253c46e0ccfb5eed4fe0f3f0a3e89bf348deb096be9b6e02fd0b8211f"
-    sha256 cellar: :any,                 monterey:       "2a175ad12f66dce52f2b148332c66c3952d66eaeaf38105c3166a5bc1bf57dbb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6768715f4331954c61ff222a4765100bd0ac3ffa1902c00c183494a6a0bd191a"
+    sha256 cellar: :any,                 arm64_sonoma:   "260bfc8da5d28164cbaac15050ebedf3896f6ceb5604f2c4c83369e728777a97"
+    sha256 cellar: :any,                 arm64_ventura:  "d62291c3e429c3a3e12f7a7205781519efae7839a588956acfd8744dce4ac8fb"
+    sha256 cellar: :any,                 arm64_monterey: "8dfb0f38b625a3759465a173db60ad1824318ca763de2381dc97cb189915cc1a"
+    sha256 cellar: :any,                 sonoma:         "b80a4739c18cbed3b93068f892ebd873fefc31d0fc4fae13c446c9f193ff68d6"
+    sha256 cellar: :any,                 ventura:        "c16263a156b83826465f41f817bc6128026c5844b5645a9ca2225ee1063c2bac"
+    sha256 cellar: :any,                 monterey:       "e968eaf16af0ad7d5560692eae3e32701fdb4926e4cdcb55163e12a22c671c4f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "962d2e5a37edb8edf7826b98edb54de7e36566a440f5a91e67d6bf3d74858032"
   end
 
   depends_on "ninja" => :build

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -4,6 +4,7 @@ class Folly < Formula
   url "https://github.com/facebook/folly/archive/refs/tags/v2024.04.15.00.tar.gz"
   sha256 "3d59eb2acdeec40d662cd48fc37c5f3888f1dbc784064365dda223d67958ee26"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/folly.git", branch: "main"
 
   bottle do

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -8,13 +8,13 @@ class Folly < Formula
   head "https://github.com/facebook/folly.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c8c669a3526fffbfcf61524cc49dd3245e74dff7860f45da1500c28e33d8a5cd"
-    sha256 cellar: :any,                 arm64_ventura:  "87842ce3b31330d3472aceaf2a9bf648c8f301445ba445221483a85845f6f1cc"
-    sha256 cellar: :any,                 arm64_monterey: "c65ba459743eb0781a36b48faf55c432417cbdfaf2c833aaa361f4b37686a21b"
-    sha256 cellar: :any,                 sonoma:         "a71ee5171f503db8ce20de6272005d8e0bdf2b9e4a9404fcf3aaf7c5a634262c"
-    sha256 cellar: :any,                 ventura:        "581c5ce1d587a8aec27e86a866a10f53b2dbd01657a39ee548b6703a79f7aaca"
-    sha256 cellar: :any,                 monterey:       "e96be58446fa4ce3d0701b27755cb8227d055752e4f0f068db6d703535399616"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a0f58c4321f6b10de4ddca27d5f1372af9c719e5beca9d32c794391451d47a70"
+    sha256 cellar: :any,                 arm64_sonoma:   "03e4a02fc7b90fa6e1755c573dd9695c0a7bdfa4cd7aa171882766816a5dc0b7"
+    sha256 cellar: :any,                 arm64_ventura:  "62c97971048386111f5e903ea4e757a8fa60440158c46e773422584dd8d00fe1"
+    sha256 cellar: :any,                 arm64_monterey: "1d00cce03b997f98441c5bf95e9ff0d4a472d16d5cf186ae3c9cc38278adfc07"
+    sha256 cellar: :any,                 sonoma:         "6598034c3e48211f7ea7fd46a2368099cef5f0d08a2be5843191c71c7f79c8b1"
+    sha256 cellar: :any,                 ventura:        "74737b0f0c6e284b46ab4c0bc18b3d0183c974f89c61bc72cfaa717f7c6c13ae"
+    sha256 cellar: :any,                 monterey:       "1a0fb78aa39b7bae0fca1b2777d00607d68c351ff642b1fa9e6bcebd148805b2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ec03d0583e6ac173d38b80649c87d2ed65b7ff7eaeaf37b77a08eb80333f29b9"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/gifski.rb
+++ b/Formula/g/gifski.rb
@@ -1,10 +1,9 @@
 class Gifski < Formula
   desc "Highest-quality GIF encoder based on pngquant"
   homepage "https://gif.ski/"
-  url "https://github.com/ImageOptim/gifski/archive/refs/tags/1.14.4.tar.gz"
-  sha256 "7d6b1400833c31f6a24aac3a1b5d44c466e07f98af6d6c17487a7c8c6f4aa519"
+  url "https://github.com/ImageOptim/gifski/archive/refs/tags/1.32.0.tar.gz"
+  sha256 "9a9145c31936f6e6e3b30e7feb8a741bcc02e8bcec6fd480d03c25ffa55f372c"
   license "AGPL-3.0-only"
-  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "33386a67249fbbff0c640beee7acd1c9ffe3778d1cdd59c50e68e9c058faf477"

--- a/Formula/g/gifski.rb
+++ b/Formula/g/gifski.rb
@@ -6,13 +6,13 @@ class Gifski < Formula
   license "AGPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "33386a67249fbbff0c640beee7acd1c9ffe3778d1cdd59c50e68e9c058faf477"
-    sha256 cellar: :any,                 arm64_ventura:  "433365d8811a26048c1034616d1f6497674f095019b23ce4b7363937f1dfd3b7"
-    sha256 cellar: :any,                 arm64_monterey: "5bd97a8e3795ec2f82cd0339d6011f4dd8b47fc26e3ad4dd3c1d156eaa0e061c"
-    sha256 cellar: :any,                 sonoma:         "045ef48c53efdd0d2acbf3907b87fb29c94fbbc1ca58e14a566ce2529695e6d3"
-    sha256 cellar: :any,                 ventura:        "c9da57fcca75648dcecef8f1c09d74d2a9c3a6a8f8afb181c977d41adf5d9b12"
-    sha256 cellar: :any,                 monterey:       "82c0c350f48464e8af0fc0dba896372d59f92c6797af8634ba58f038484623ae"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "01aae113b0bc2090e6c7d3004cc5f5afb1aaddb4917cf512a36abb34f297b8fb"
+    sha256 cellar: :any,                 arm64_sonoma:   "7eed39c25338fafdfb6547e305a02f137c10e6624852be3c60dfa36527be35de"
+    sha256 cellar: :any,                 arm64_ventura:  "482fba0d44f69d1e5b137051022f2ab2fd83ed61ecee0f34d9e6909a422c9dac"
+    sha256 cellar: :any,                 arm64_monterey: "c0e54ca91ce8e920d50461c7bef2432881f9ddc347648f23617c871b1448611a"
+    sha256 cellar: :any,                 sonoma:         "106b8f0b03fc6e059aec0d3274f92da8ae33cc0919980d60a36e0b8917046755"
+    sha256 cellar: :any,                 ventura:        "e4320c33cbe202bdcab24640377483950c90ee27c47192791300c109f190a8df"
+    sha256 cellar: :any,                 monterey:       "f68b1f53e4ee3b59a627f93752461a68f94711e7c8cc68f4fa3e7c0883cf75f3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2b5acc7e25a1311ea15611f213bbe144de06db490c002321bda776eeb0722b22"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/g/git-extras.rb
+++ b/Formula/g/git-extras.rb
@@ -1,8 +1,8 @@
 class GitExtras < Formula
   desc "Small git utilities"
   homepage "https://github.com/tj/git-extras"
-  url "https://github.com/tj/git-extras/archive/refs/tags/7.1.0.tar.gz"
-  sha256 "e5c855361d2f1ec1be6ee601247153d9c8c04a221949b6ec3903b32fa736f542"
+  url "https://github.com/tj/git-extras/archive/refs/tags/7.2.0.tar.gz"
+  sha256 "f570f19b9e3407e909cb98d0536c6e0b54987404a0a053903a54b81680c347f1"
   license "MIT"
   head "https://github.com/tj/git-extras.git", branch: "main"
 

--- a/Formula/g/git-extras.rb
+++ b/Formula/g/git-extras.rb
@@ -7,14 +7,13 @@ class GitExtras < Formula
   head "https://github.com/tj/git-extras.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "056792c05a926101be794b3bba82fe69e29fc4425b90b9d35e626f661905aa34"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "056792c05a926101be794b3bba82fe69e29fc4425b90b9d35e626f661905aa34"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "056792c05a926101be794b3bba82fe69e29fc4425b90b9d35e626f661905aa34"
-    sha256 cellar: :any_skip_relocation, sonoma:         "056792c05a926101be794b3bba82fe69e29fc4425b90b9d35e626f661905aa34"
-    sha256 cellar: :any_skip_relocation, ventura:        "056792c05a926101be794b3bba82fe69e29fc4425b90b9d35e626f661905aa34"
-    sha256 cellar: :any_skip_relocation, monterey:       "056792c05a926101be794b3bba82fe69e29fc4425b90b9d35e626f661905aa34"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6d2fe250aa7a848dc82c8fb443db5767c70abbc9ec45de4c0c0e938c620c5319"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
+    sha256 cellar: :any_skip_relocation, ventura:        "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
+    sha256 cellar: :any_skip_relocation, monterey:       "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7167b10ce60d43bcde34c76cd8f1aec92d5d98d05f93e95b98fc140bee0d7b86"
   end
 
   on_linux do

--- a/Formula/g/gitlab-gem.rb
+++ b/Formula/g/gitlab-gem.rb
@@ -66,6 +66,6 @@ class GitlabGem < Formula
     ENV["GITLAB_API_ENDPOINT"] = "https://example.com/"
     ENV["GITLAB_API_PRIVATE_TOKEN"] = "token"
     output = shell_output("#{bin}/gitlab user 2>&1", 1)
-    assert_match "Server responded with code 404", output
+    assert_match "404 - Not Found", output
   end
 end

--- a/Formula/h/hurl.rb
+++ b/Formula/h/hurl.rb
@@ -1,8 +1,8 @@
 class Hurl < Formula
   desc "Run and Test HTTP Requests with plain text and curl"
   homepage "https://hurl.dev"
-  url "https://github.com/Orange-OpenSource/hurl/archive/refs/tags/4.2.0.tar.gz"
-  sha256 "8ede2b3e9e1e1fb80000362750814b0fd07911506c1ea13e38e6c2fe80f447f0"
+  url "https://github.com/Orange-OpenSource/hurl/archive/refs/tags/4.3.0.tar.gz"
+  sha256 "499f2430ee6b73b0414ab8aa3c9298be8276e7b404b13c76e4c02a86eb1db9cd"
   license "Apache-2.0"
   head "https://github.com/Orange-OpenSource/hurl.git", branch: "master"
 
@@ -39,6 +39,13 @@ class Hurl < Formula
 
     man1.install "docs/manual/hurl.1"
     man1.install "docs/manual/hurlfmt.1"
+
+    bash_completion.install "completions/hurl.bash" => "hurl"
+    zsh_completion.install "completions/_hurl"
+    fish_completion.install "completions/hurl.fish"
+    bash_completion.install "completions/hurlfmt.bash" => "hurlfmt"
+    zsh_completion.install "completions/_hurlfmt"
+    fish_completion.install "completions/hurlfmt.fish"
   end
 
   test do

--- a/Formula/h/hurl.rb
+++ b/Formula/h/hurl.rb
@@ -15,13 +15,13 @@ class Hurl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "512d0785ee1d0a7c0018456e1a278a954ec27b119b78ea0d2fa61064322d7a20"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "760dc757577039dcb20ddde4c8c526664323f612e54a49f147d1922bf555a36c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "419e468299ab898cd8f5a1f0521f5ba0dd5285502ff697f33decd6d5394576de"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d584ba2a31de44955ca4f01b4532ae534d1c5224dc6fee86036662e1fe179b4a"
-    sha256 cellar: :any_skip_relocation, ventura:        "ec474a707f443154b9ad65edb83f118e5ecfa55bdf033cbd667af621a6606fb8"
-    sha256 cellar: :any_skip_relocation, monterey:       "dfd3ced2b4140549960f243925d7cc8c6f7fb55a6dc325bb38bc6206cdea60b7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "595509b4765b5d763d12f7d1cbf8e4987ac77c5253195372a2660da01d8d408b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5ee7cf447f030597d82e8a83ee37107b818598dac1ea3af04f6f80ee4120012f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "dff40910852829139374fb29e7ecc79d9020552c72518ce3b25b5bec372a5858"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "990b4814e7ff7969f96a08b7718868c5ec687f5ac348aa376da58e7cec5fe01f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "539dc8fa94b7bc1e919b5a26851ba01ccb6c2330678b1e0870ddd90097893b01"
+    sha256 cellar: :any_skip_relocation, ventura:        "917abbae8169238b16283dca3607fa475dfdda7acc1083e9c2fd1db708262667"
+    sha256 cellar: :any_skip_relocation, monterey:       "73e46d317b0d87acec0bb6e97e56bd7ed4b457cc71e57c06506db73ffe064b2b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1d02a94cbdaa80a5f743df78ae6c9b343711467af394d1251afb4dd13c814d17"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/k/kn.rb
+++ b/Formula/k/kn.rb
@@ -2,8 +2,8 @@ class Kn < Formula
   desc "Command-line interface for managing Knative Serving and Eventing resources"
   homepage "https://github.com/knative/client"
   url "https://github.com/knative/client.git",
-      tag:      "knative-v1.13.0",
-      revision: "543522a33edc79e056c09e4f9b78135e4fed5307"
+      tag:      "knative-v1.14.0",
+      revision: "6a1449c2e8a8b5fd667cac65164506ad9632ef4d"
   license "Apache-2.0"
   head "https://github.com/knative/client.git", branch: "main"
 

--- a/Formula/k/kn.rb
+++ b/Formula/k/kn.rb
@@ -8,13 +8,13 @@ class Kn < Formula
   head "https://github.com/knative/client.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1ad9e97b0daa1c78969883c900a533baf6e599702b9bb28dfec4e8a5132be261"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1ad9e97b0daa1c78969883c900a533baf6e599702b9bb28dfec4e8a5132be261"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1ad9e97b0daa1c78969883c900a533baf6e599702b9bb28dfec4e8a5132be261"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c9b4bbcfa3ac481854dfb22229667710509a0243f2a7051bb15df9dbc2832580"
-    sha256 cellar: :any_skip_relocation, ventura:        "c9b4bbcfa3ac481854dfb22229667710509a0243f2a7051bb15df9dbc2832580"
-    sha256 cellar: :any_skip_relocation, monterey:       "c9b4bbcfa3ac481854dfb22229667710509a0243f2a7051bb15df9dbc2832580"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b44b8ce2c8264a10884cac443b60bae6357ea6a069baaa870023b01c70d65d66"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "676250ff01a46dcb077144490c254d73f26cb000a4c0ba2877bf137af14ec91c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "676250ff01a46dcb077144490c254d73f26cb000a4c0ba2877bf137af14ec91c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "676250ff01a46dcb077144490c254d73f26cb000a4c0ba2877bf137af14ec91c"
+    sha256 cellar: :any_skip_relocation, sonoma:         "a5e7c5ed68d72349507aeda24e2412a241177a2557c2dce855dc933b2de9bb1c"
+    sha256 cellar: :any_skip_relocation, ventura:        "a5e7c5ed68d72349507aeda24e2412a241177a2557c2dce855dc933b2de9bb1c"
+    sha256 cellar: :any_skip_relocation, monterey:       "a5e7c5ed68d72349507aeda24e2412a241177a2557c2dce855dc933b2de9bb1c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f66782ff5a206c86ab4c0e582c3ee87637560aa6131bb030286da86b2ade7ec6"
   end
 
   depends_on "go" => :build

--- a/Formula/k/kubeshark.rb
+++ b/Formula/k/kubeshark.rb
@@ -1,8 +1,8 @@
 class Kubeshark < Formula
   desc "API Traffic Analyzer providing real-time visibility into Kubernetes network"
   homepage "https://www.kubeshark.co/"
-  url "https://github.com/kubeshark/kubeshark/archive/refs/tags/v52.2.30.tar.gz"
-  sha256 "fd0af9cb4c080866481843bd147905b4d3791a3dd1c80970404b3260a232090f"
+  url "https://github.com/kubeshark/kubeshark/archive/refs/tags/v52.2.39.tar.gz"
+  sha256 "c1ee1ae0b46717cc76f014a02ef0477b4e1ee0ea114ebe7ea9d3a877355f2db5"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/k/kubeshark.rb
+++ b/Formula/k/kubeshark.rb
@@ -6,13 +6,13 @@ class Kubeshark < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "30af2126ba92a84c11a030b80accc399cf3b806cabb4b9a2da7512ce4841133e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "32069866c31dfd3eaebe6f04989293316affb4c08f9361b7b9dbb9f954d76c72"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a85ee8866dbca6835c9ffe2beaf4b1651bb53e8446e42b4a11459c7e0ea7409f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "612ad80baa760a2d6413d7e5475522be63588631bac6d18674542859669ffe88"
-    sha256 cellar: :any_skip_relocation, ventura:        "7fba129c8716f67d5228d330c3b947ffe7635a3cc9b43d0c6712b4f782a3355d"
-    sha256 cellar: :any_skip_relocation, monterey:       "06e8b909d9015c93e66886bf9dc186c54136a4a9eeea920666e05970ad2ce892"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "691556dabad7e7450ffdd658e49bed772648547a91a30d4a3054fd4baec39db5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "579bfd46c81081269da277adf3148123f723cca74fb7363067f512736228215c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "55ff01e3e7329603ce4864c3b0eb552a2468b57d0beb889d6265666672b395a3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ff61af69744bd5a7b5432947a7fde1d34d77c7becf694468ed1ff18abe65b9fb"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d23c168aac0f42680e642f6676ed89718fb2ff03d066202e93cc706bf79403ad"
+    sha256 cellar: :any_skip_relocation, ventura:        "60197024290e3a7633603ad74d0cd0e3c4c7964b8716b64950de9a4abc73d080"
+    sha256 cellar: :any_skip_relocation, monterey:       "9098fd5f717ee7c9f6138990df86e135e8cd5f9661f91236f4353501cdac328a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "037bdedbefb03fb8f8f21ae95c52a154312b50cc359b796737e9e34d2c2ea748"
   end
 
   depends_on "go" => :build

--- a/Formula/k/kwctl.rb
+++ b/Formula/k/kwctl.rb
@@ -1,8 +1,8 @@
 class Kwctl < Formula
   desc "CLI tool for the Kubewarden policy engine for Kubernetes"
   homepage "https://www.kubewarden.io/"
-  url "https://github.com/kubewarden/kwctl/archive/refs/tags/v1.11.0.tar.gz"
-  sha256 "2f5f96a4fea96d42826ad29a4246c595024d25b7745996b0125e9ac7587f70c9"
+  url "https://github.com/kubewarden/kwctl/archive/refs/tags/v1.12.0.tar.gz"
+  sha256 "0b2f4e821c604ba0501c5805c14d613609fdb7cb9089bd8d0dfd6ad186a8d96f"
   license "Apache-2.0"
   head "https://github.com/kubewarden/kwctl.git", branch: "main"
 

--- a/Formula/k/kwctl.rb
+++ b/Formula/k/kwctl.rb
@@ -7,13 +7,13 @@ class Kwctl < Formula
   head "https://github.com/kubewarden/kwctl.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2cfec747a1871dc637e53ca4cf89b919733fc5c552b3b108351e55a65c2a503f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cc2d52a9c049fb74da63617ce3712c362a3a6c49a97d52d1a48bfb20b58b261f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "38a9bf9b21d06ef4ae0adbc028990927472c6efe28b6d5cf293e442655bfeb70"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f522d66a7d4e8952931475968533a5c124e264557ac3973c74ac96bbfaed79cd"
-    sha256 cellar: :any_skip_relocation, ventura:        "c26afff84109b9303e6947e22e561259d88aa926305383fd5357e60bdcc3c96a"
-    sha256 cellar: :any_skip_relocation, monterey:       "91e198473100802a69bdc1800d6cdc6bff3d4874ad2b34c3aaeef7be98f79df4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6af1d64442412b93b20b290a4b7d2c61f186158aa343ec45dd99ca7dac9426b9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b539eb74b893f414aee2ce948130d40c5490c4abb501fe9f5e11d665ba4a2cb1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0dc829ea2ce3ac6bd98ca2de81be012aee3936f3be65555c166979b610291e78"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f1ea2c53050c7ec386933415259cebc9f70b812e3d7f01049e3e8be339de9cbf"
+    sha256 cellar: :any_skip_relocation, sonoma:         "535d0cd31ba18bc483bbc44413f6d813235832a25b0fc5b32d91730ccd89ca9f"
+    sha256 cellar: :any_skip_relocation, ventura:        "cbbd0755ba18a98302945de9d7894fe4fd3f55f2dfb219f1c9ecb19ccf0c013d"
+    sha256 cellar: :any_skip_relocation, monterey:       "fde55bfab428a1881e8bdda0c786ab5f08c2452c1b1edac3172044e57c7a0d66"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d66443c7c97616914a139478efaba0dc84473876eaefa2410be73651e677e2b4"
   end
 
   depends_on "rust" => :build

--- a/Formula/l/leveldb.rb
+++ b/Formula/l/leveldb.rb
@@ -4,6 +4,7 @@ class Leveldb < Formula
   url "https://github.com/google/leveldb/archive/refs/tags/1.23.tar.gz"
   sha256 "9a37f8a6174f09bd622bc723b55881dc541cd50747cbd08831c2a82d620f6d76"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "8d18b1cabb2b8e9bcf79655774037cce9f9ea523d8d4c2dcc271bcfb40d06904"

--- a/Formula/l/leveldb.rb
+++ b/Formula/l/leveldb.rb
@@ -7,17 +7,13 @@ class Leveldb < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "8d18b1cabb2b8e9bcf79655774037cce9f9ea523d8d4c2dcc271bcfb40d06904"
-    sha256 cellar: :any,                 arm64_ventura:  "1d80f7684ef784f83b4f9312434a694c74e58351fd4eaab2641f6ef28bcda5ea"
-    sha256 cellar: :any,                 arm64_monterey: "41f1ceea1e85dafe0552acf94a4903ef45fd54fc63e38c277b7d101c836e5801"
-    sha256 cellar: :any,                 arm64_big_sur:  "377ac4b779d9ac24295b99c5f859dc8f78f473e62a90849f09eeec7a72d872d2"
-    sha256 cellar: :any,                 sonoma:         "7805a087ee6ab40f24e0d8c0c29b6ced89d85ec2b6e0297d0ea93600b9b38471"
-    sha256 cellar: :any,                 ventura:        "4e5b8daba28db15b42a1a6d7c9f1bdc301906ca87889518522e7eb4ba0eb65f5"
-    sha256 cellar: :any,                 monterey:       "3b4ce296ae8732cdec0b9fdc3623a5c12f8739b61c39cdb96be423e8004834be"
-    sha256 cellar: :any,                 big_sur:        "bb5f8bc871e315e4ae36f011052f2b92e35040cc03ef8d448093e7be1bdfe6ac"
-    sha256 cellar: :any,                 catalina:       "299f9004aa344b2ac164fdeee5a077c3e45335f3527cb8f2e67b46acf88b185a"
-    sha256 cellar: :any,                 mojave:         "b4d54e51eef8d5d538830f555561fa4cc5f1b275b45588eae364d79de6b1d716"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c056f3b6a5e2b25d90b57255138ce65796615d0e66d7156821b13ebbe8f836cd"
+    sha256 cellar: :any,                 arm64_sonoma:   "8d31999d036ab81506c70b2e446a4fc62457307a610e9af51538cea0e592fd4b"
+    sha256 cellar: :any,                 arm64_ventura:  "b7ca49e08f08c52f9a2c7f67dbcbd1214ca97023d1173f943d8df0a4dda66c55"
+    sha256 cellar: :any,                 arm64_monterey: "666c5e8c3f01854847176459ee4fc06d3248dfda68e8249b2186777c09cab373"
+    sha256 cellar: :any,                 sonoma:         "98aa66f907f2e279295bb6691302388264f6fc141128703ce4bfd315531815d2"
+    sha256 cellar: :any,                 ventura:        "48d595e1d25c23f2376ba436b3a89913f9babbd0d715f4029d9eff7174923215"
+    sha256 cellar: :any,                 monterey:       "327dd3eac9c6a481c5f7e578f815d6b3f3d912c33e47c4e15dd5ccce85a2bd16"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "240f267390c10b75634da1be1bf04e0878819ef79d6d79fb52a4507adb47908b"
   end
 
   depends_on "cmake" => :build

--- a/Formula/lib/libpulsar.rb
+++ b/Formula/lib/libpulsar.rb
@@ -5,6 +5,7 @@ class Libpulsar < Formula
   mirror "https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.5.1/apache-pulsar-client-cpp-3.5.1.tar.gz"
   sha256 "d24990757319dfa9c9e5d3263f60105dd9e12ddeaf1396d6b397f87dab2fd7d1"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "a08b3483b74be83bc5ccecb061825df782d4f034e39c9fb4cb7c57a6d9a6a1c9"
@@ -27,11 +28,10 @@ class Libpulsar < Formula
   uses_from_macos "curl"
 
   def install
-    args = %w[
+    args = %W[
       -DBUILD_TESTS=OFF
-      -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON # protocolbuffers/protobuf#12292
-      -Dprotobuf_MODULE_COMPATIBLE=ON # protocolbuffers/protobuf#1931
       -DCMAKE_CXX_STANDARD=17
+      -DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}
     ]
 
     system "cmake", "-S", ".", "build", *args, *std_cmake_args

--- a/Formula/lib/libpulsar.rb
+++ b/Formula/lib/libpulsar.rb
@@ -8,13 +8,13 @@ class Libpulsar < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "a08b3483b74be83bc5ccecb061825df782d4f034e39c9fb4cb7c57a6d9a6a1c9"
-    sha256 cellar: :any,                 arm64_ventura:  "21515bff2543c94ae83043cbc4aa8ad0a81adf27cd5a48a0dfb89e42c0e4f94b"
-    sha256 cellar: :any,                 arm64_monterey: "f683513f15b32eddcabc1f7189f996d2e1b529eba88b9d852f765c323754ae6a"
-    sha256 cellar: :any,                 sonoma:         "9de9907d629344d85aea0db2dc90eed47bab34fe7562a4e6e60d8b760db88b20"
-    sha256 cellar: :any,                 ventura:        "2dfbdae8e6b3130179a2306025006d37bab8899906544abbb0da1522cc1a65d1"
-    sha256 cellar: :any,                 monterey:       "dd274f1f6042234cbbe75b40c2f6dded59d38ffdc8e8737a38c26bf93cf1f07d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3447063797b661017795f2a6bc02af991e687614234a0ad864870b5808f83ddc"
+    sha256 cellar: :any,                 arm64_sonoma:   "3fff111a7b587706434cab7912abad51ce873fa2ea2dda118f5935b244cd4963"
+    sha256 cellar: :any,                 arm64_ventura:  "d269e47fe644c6610b7f889dbc0349a52eae2a4539498dac248b73050bc73195"
+    sha256 cellar: :any,                 arm64_monterey: "b17867e7525e48fc192dd2405daa135d35c70fec6e13e50953fb77355cd2cdc5"
+    sha256 cellar: :any,                 sonoma:         "ae47fbc2f5e85f1fcfc53d9f7334663230b8e5188b144b480e83c7dbed8a0d92"
+    sha256 cellar: :any,                 ventura:        "d159bf901ff1d4855d7bda034b744462751543d138f1da83feb0e1fdeef04223"
+    sha256 cellar: :any,                 monterey:       "e0337b7fc58357c45f72843a2767c5e96f60704614545d71dfc77f8c3102b7bf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4bf3f1bd4618b31ed18a970964638271218d00f302d87dd9d8ededff297af0d0"
   end
 
   depends_on "cmake" => :build

--- a/Formula/m/mongosh.rb
+++ b/Formula/m/mongosh.rb
@@ -8,13 +8,13 @@ class Mongosh < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256                               arm64_sonoma:   "8c284258fbd95f957a3b9bce11835a29bddf7b271330b1c2d7e893739dbe95c3"
-    sha256                               arm64_ventura:  "28dabb81fadfa0adad57dbce2fe5a42c7d495ee4e1557ad767109fe0efc59e9e"
-    sha256                               arm64_monterey: "fa6da0b14ec9902a86cc8237eb3849d8a537d6a38afacc03634e76255455d9f9"
-    sha256                               sonoma:         "d3aa9bba0e18fceb4534d41e065ee5069ab1a6d359570ad2b39973415f63301b"
-    sha256                               ventura:        "f893c2e8ff6cd0c7dea1c4c3928f1acd0031a4cc77fa1a7150f0c24b353c47e1"
-    sha256                               monterey:       "3abe54213b39af006d6487c4cce4d361198558db27573f1632fed8500b55401d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3cc458f42e3974b2a01f0332630cef273fdc2790d164b47a196a50f5b552e72b"
+    sha256                               arm64_sonoma:   "7f239cc177f9ee9c8aab20998e5e8a9fa7a4f4e533a34add60f089a66498bf33"
+    sha256                               arm64_ventura:  "01713c308d702c9e2f27fb537df755a16a491b9161ec4a17fc159123b2c7fdc4"
+    sha256                               arm64_monterey: "080a5ba05c02c4a312aafc3a4862b95bdec06c3a81e91a23369b0d4c261d3d8d"
+    sha256                               sonoma:         "d310ec49076d53412a8fd8914c4354bffb598cf1136c6758f5d67896003e94ee"
+    sha256                               ventura:        "d24fbce564ae37bd784474d13d3b673c6e4749f29c9ee85827dc202ae58dfdf4"
+    sha256                               monterey:       "e4b35d8d4baf5bd937d091949ef41297cfc7ac65481a0128239d03145709c3c3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "85e0e84b3e950e2bd29845d60b15f3865d70010388ef599bbaaa39baed0588db"
   end
 
   depends_on "node"

--- a/Formula/m/mongosh.rb
+++ b/Formula/m/mongosh.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Mongosh < Formula
   desc "MongoDB Shell to connect, configure, query, and work with your MongoDB database"
   homepage "https://github.com/mongodb-js/mongosh#readme"
-  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-2.2.4.tgz"
-  sha256 "a94f0e947352e10dfdaa1e3188ed8aa251b901d0c3aa1923fd3284036b26b2e0"
+  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-2.2.5.tgz"
+  sha256 "9830f25f4c32a1e6c63d64de97694053b07c1905540df553ce72ec85ecd583bd"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/m/mypy.rb
+++ b/Formula/m/mypy.rb
@@ -9,13 +9,13 @@ class Mypy < Formula
   head "https://github.com/python/mypy.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1be58251888cd3febd565416be5e22504defa9de1ef64843f7f64e662df199cd"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4e02ade4c58efbee1b5aa5aea88a5057591097bc2f94e28dc8c1af2510e01cc5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b678ece22b353db48764126f048e20f2f0dd3e2b830179ff6d8333d3ad65924b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ed126de7e65f85460894ed3b5fdeb28cb7a40b0b7484ddf1c2e1cf1e3031e787"
-    sha256 cellar: :any_skip_relocation, ventura:        "461700209f73048aa3adcb08dfbdb8d2fa4950885d5975e45b6583a51ff9e7b5"
-    sha256 cellar: :any_skip_relocation, monterey:       "166e2fe8da0abecccb95bd8a37a0ec879e50fa4cc79be35ec43e95bbe9243a2b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9f32a3322277ef33aec9170de0dde330f99a963924a36785bde368673c00981a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dcbb33b8591fd579d3e0336ec22be82ad50aea66b3f66a524cc4b723ef4b16b9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3421f3f4d35d49b229fd88046336c5ce06187b8d2810bb2a6e5b055bd1ba906f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "12dabf47a8b5ffc37ec101d133a2b6e14f611b5f8b8ff516172deec8f403d15b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0c0d8c7c935d310f3f1c02673f537c86f1582330d4f44d2ec2d9db5715a55d4e"
+    sha256 cellar: :any_skip_relocation, ventura:        "45ab4f8e893d5df6d32776aae49b984bc363bf60af0d65fb8178730d662b5b19"
+    sha256 cellar: :any_skip_relocation, monterey:       "bd9cb33745275ba357724fbd328f5a249e905a9d0667ece81ac749ea5c22af4b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d39a13321c4cc7df27d46627603f044de87db9318c51599537f7d28166c97b1d"
   end
 
   depends_on "python@3.12"

--- a/Formula/m/mypy.rb
+++ b/Formula/m/mypy.rb
@@ -3,8 +3,8 @@ class Mypy < Formula
 
   desc "Experimental optional static type checker for Python"
   homepage "https://www.mypy-lang.org/"
-  url "https://files.pythonhosted.org/packages/72/1e/a587a862c766a755a58b62d8c00aed11b74a15dc415c1bf5da7b607b0efd/mypy-1.9.0.tar.gz"
-  sha256 "3cc5da0127e6a478cddd906068496a97a7618a21ce9b54bde5bf7e539c7af974"
+  url "https://files.pythonhosted.org/packages/c3/b6/297734bb9f20ddf5e831cf4a83f422ddef5a29a33463999f0959d9cdc2df/mypy-1.10.0.tar.gz"
+  sha256 "3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131"
   license "MIT"
   head "https://github.com/python/mypy.git", branch: "master"
 
@@ -26,8 +26,8 @@ class Mypy < Formula
   end
 
   resource "typing-extensions" do
-    url "https://files.pythonhosted.org/packages/16/3a/0d26ce356c7465a19c9ea8814b960f8a36c3b0d07c323176620b7b483e44/typing_extensions-4.10.0.tar.gz"
-    sha256 "b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+    url "https://files.pythonhosted.org/packages/f6/f3/b827b3ab53b4e3d8513914586dcca61c355fa2ce8252dea4da56e67bf8f2/typing_extensions-4.11.0.tar.gz"
+    sha256 "83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"
   end
 
   def install

--- a/Formula/n/ncdu.rb
+++ b/Formula/n/ncdu.rb
@@ -1,8 +1,8 @@
 class Ncdu < Formula
   desc "NCurses Disk Usage"
   homepage "https://dev.yorhel.nl/ncdu"
-  url "https://dev.yorhel.nl/download/ncdu-2.3.tar.gz"
-  sha256 "bbce1d1c70f1247671be4ea2135d8c52cd29a708af5ed62cecda7dc6a8000a3c"
+  url "https://dev.yorhel.nl/download/ncdu-2.4.tar.gz"
+  sha256 "4a3d0002309cf6a7cea791938dac9becdece4d529d0d6dc8d91b73b4e6855509"
   license "MIT"
   head "https://g.blicky.net/ncdu.git", branch: "zig"
 
@@ -36,7 +36,7 @@ class Ncdu < Formula
     else Hardware.oldest_cpu
     end
 
-    args = %W[--prefix #{prefix} -Doptimize=ReleaseFast]
+    args = %W[--prefix #{prefix} --release=fast]
     args << "-Dpie=true" if OS.mac?
     args << "-Dcpu=#{cpu}" if build.bottle?
 

--- a/Formula/n/ncdu.rb
+++ b/Formula/n/ncdu.rb
@@ -12,15 +12,13 @@ class Ncdu < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "7c17a54a1c133f106b8ccc577241b977d76de394568b838107c5c397291b6759"
-    sha256 cellar: :any,                 arm64_ventura:  "be4225e9e3a60fc201015d0b347b4d6aa91716ec87b48329f5a3fb64201aaede"
-    sha256 cellar: :any,                 arm64_monterey: "b9811c7444bc9803111b4473484019a83da067071e7cfbd0e8dfb53970a57098"
-    sha256 cellar: :any,                 arm64_big_sur:  "d6e1ccd31a5f1f1f6957743f625444e3cc6328be9831eb0f618c98a6f314e2ad"
-    sha256 cellar: :any,                 sonoma:         "690b4e39230bf4639b770f7aa7156a80da6831a51d5344dc177bb23bc04002a1"
-    sha256 cellar: :any,                 ventura:        "d7904cf9cf2980d12c5db4f69c9d19b0533fab76190de548af0c69012f1eafd9"
-    sha256 cellar: :any,                 monterey:       "c0aeb8ca6c14b2475bd5a60a5b8fc08ba8def91abad411b32a06c88a85597fef"
-    sha256 cellar: :any,                 big_sur:        "739dd2be415a7edaff71ab49ac6c5afb830dba6d66ceffe6f54b7683d0e5dfaa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a6619212d336a2472d712eebc2c44239164ca8253fef4c09ec5268493ba41568"
+    sha256 cellar: :any,                 arm64_sonoma:   "10de74d4c9b0e950712a13e2f1b08ebc59abf6e68306a9e5e3d1fb452cc6127b"
+    sha256 cellar: :any,                 arm64_ventura:  "beeb416eb7033954b972e34c883997949fb39d30c616d7d8f112e94e5c0cad9a"
+    sha256 cellar: :any,                 arm64_monterey: "e33bab1bfa37760234049cb7ba9fa2e66b58dd7da22fc1a657ec04215a74723e"
+    sha256 cellar: :any,                 sonoma:         "d9798da4a4ac01005a01428d421d4fee7b4680a8cc22d70322e193aa88cc1203"
+    sha256 cellar: :any,                 ventura:        "1766460676314d7c3ea2800fcd653d3eeab53d22a168d80eca343a219dbc2ff9"
+    sha256 cellar: :any,                 monterey:       "9e1560f5ec4857297172f51520a77882c547f77928f61e9a11b503cd3ae5e948"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9158a5626debef36c3e146f48f30a5ad5088ee9d0920f71119fa4e38ced25175"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/n/node_exporter.rb
+++ b/Formula/n/node_exporter.rb
@@ -1,8 +1,8 @@
 class NodeExporter < Formula
   desc "Prometheus exporter for machine metrics"
   homepage "https://prometheus.io/"
-  url "https://github.com/prometheus/node_exporter/archive/refs/tags/v1.7.0.tar.gz"
-  sha256 "5da1dcc3608db663fc1949042c6f3ec29184c9414c37c0e2bdfe9b19fd5d75c7"
+  url "https://github.com/prometheus/node_exporter/archive/refs/tags/v1.8.0.tar.gz"
+  sha256 "57b5c0d15a37d497f95a8ba08988c4fd8a7145644b94840e91dc54b61a756cad"
   license "Apache-2.0"
   head "https://github.com/prometheus/node_exporter.git", branch: "master"
 

--- a/Formula/n/node_exporter.rb
+++ b/Formula/n/node_exporter.rb
@@ -12,13 +12,13 @@ class NodeExporter < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f76a194f122166285bf9c474caab734c8fa97da7bc850bba2f355d6806bfdf1a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "87d341e368d2981ec53e89b01d6ba07f7892c53866235de412c5375fd2a43c47"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8aab3eeb2d1e5d6074c1beb9c18e0ef9bcb9f5a6b5a2aed14ccd765d94002c5d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "e1475ad56abbb4a653c2e659f4682ea88792661c736a180df66c7a59625cf79d"
-    sha256 cellar: :any_skip_relocation, ventura:        "3211e9968caf7fdc3f505d158daf11d6de5bf4e94415cfba13325c0c45e3f9f2"
-    sha256 cellar: :any_skip_relocation, monterey:       "f92559ea54bb3e19583342cccf0b3b95e8f62abfa381d598f85275e6ee5d522c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5b3d333695b9b8dca8d94428ac7bc4719cf3e2e9015e92fdbbc2aee2ec5496b4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "782b635ccecd12edf61dfe494259b2cee9f11d7652614b874976b62cd181899e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "38f56905ffa765684abe7f4bfe8069c4818cb11f68aecd17942215260a2c1f98"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2ba81861d169182af270e6af877a7b26904af259404da63dd02cb1ee1b79a3b8"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6d0e85d58752be73e347eafc77ddaf377b19b5d0d9e44189678bbb7ae3b6f08d"
+    sha256 cellar: :any_skip_relocation, ventura:        "71215ba019c623c5e826b6a98c444c3ce34175de04e15485f27cb5fbb5a8201e"
+    sha256 cellar: :any_skip_relocation, monterey:       "51c75be7a2d1010470af40b7e4a97dab6ce5eccc7f8f89980651614f10c17c77"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "834a2f113e0a8b6e3aed4778f82efe6781df8790e739b7258c99e485efdc67a2"
   end
 
   depends_on "go" => :build

--- a/Formula/p/parsedmarc.rb
+++ b/Formula/p/parsedmarc.rb
@@ -365,10 +365,7 @@ class Parsedmarc < Formula
 
   def install
     # Multiple resources require `setuptools`, so it must be installed first
-    venv = virtualenv_create(libexec, "python3.12")
-    venv.pip_install resource("setuptools")
-    venv.pip_install resources.reject { |r| r.name == "setuptools" }
-    venv.pip_install_and_link buildpath
+    virtualenv_install_with_resources start_with: "setuptools"
   end
 
   test do

--- a/Formula/p/pnpm.rb
+++ b/Formula/p/pnpm.rb
@@ -13,13 +13,13 @@ class Pnpm < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "0af942f0fe7e501030fa8dc1ea82b1d7200ae5fa5e8ce94e39a60a937157c5d5"
-    sha256 cellar: :any,                 arm64_ventura:  "0af942f0fe7e501030fa8dc1ea82b1d7200ae5fa5e8ce94e39a60a937157c5d5"
-    sha256 cellar: :any,                 arm64_monterey: "0af942f0fe7e501030fa8dc1ea82b1d7200ae5fa5e8ce94e39a60a937157c5d5"
-    sha256 cellar: :any,                 sonoma:         "c170ca9b474b0db7c167349fdb1952ab16f09efd89234ea02075434166ffc684"
-    sha256 cellar: :any,                 ventura:        "c170ca9b474b0db7c167349fdb1952ab16f09efd89234ea02075434166ffc684"
-    sha256 cellar: :any,                 monterey:       "c170ca9b474b0db7c167349fdb1952ab16f09efd89234ea02075434166ffc684"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ed580cf570bbe1c96b449f406489ffbe00355ceafc5605a45c8f1db07908b19b"
+    sha256 cellar: :any,                 arm64_sonoma:   "a0fc1a6363fe6f9abcbe35dbd6cd17a6ad055e0e1099441a6c33c8bde024c004"
+    sha256 cellar: :any,                 arm64_ventura:  "a0fc1a6363fe6f9abcbe35dbd6cd17a6ad055e0e1099441a6c33c8bde024c004"
+    sha256 cellar: :any,                 arm64_monterey: "a0fc1a6363fe6f9abcbe35dbd6cd17a6ad055e0e1099441a6c33c8bde024c004"
+    sha256 cellar: :any,                 sonoma:         "195f27040ce2381d7110d23835ef759f91c6c581077ea65e6c2e8d848496ef51"
+    sha256 cellar: :any,                 ventura:        "195f27040ce2381d7110d23835ef759f91c6c581077ea65e6c2e8d848496ef51"
+    sha256 cellar: :any,                 monterey:       "195f27040ce2381d7110d23835ef759f91c6c581077ea65e6c2e8d848496ef51"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4306c0729e74d11685b946c3c33a0707708e61d398ed8ea671afd7d7965906c9"
   end
 
   depends_on "node" => [:build, :test]

--- a/Formula/p/pnpm.rb
+++ b/Formula/p/pnpm.rb
@@ -3,8 +3,8 @@ class Pnpm < Formula
 
   desc "Fast, disk space efficient package manager"
   homepage "https://pnpm.io/"
-  url "https://registry.npmjs.org/pnpm/-/pnpm-9.0.5.tgz"
-  sha256 "61bd66913b52012107ec25a6ee4d6a161021ab99e04f6acee3aa50d0e34b4af9"
+  url "https://registry.npmjs.org/pnpm/-/pnpm-9.0.6.tgz"
+  sha256 "0624e30eff866cdeb363b15061bdb7fd9425b17bc1bb42c22f5f4efdea21f6b3"
   license "MIT"
 
   livecheck do

--- a/Formula/p/pypy.rb
+++ b/Formula/p/pypy.rb
@@ -12,14 +12,13 @@ class Pypy < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "1fff2a4716c4b20b4ffbb822bc72ed2e01750894e4849dd293b4aa45146041bc"
-    sha256 cellar: :any,                 arm64_ventura:  "6170ced84715aee23d66a38dd616943faa198ec0bb33108aa30efcc3bad38f00"
-    sha256 cellar: :any,                 arm64_monterey: "0b568714192a7abb775d9e7d0f8f6728812446f96e6731a93503919c9a4c7cfd"
-    sha256 cellar: :any,                 sonoma:         "eaf8f8f5a361c1ac62a86601d38bc7b3a588df8895a0a6868b6c62936946331c"
-    sha256 cellar: :any,                 ventura:        "67fe0b3837efbb7a0e365e58f2c11993662782f05502de1b6a39a37171b7fb13"
-    sha256 cellar: :any,                 monterey:       "9abaf89122e36d524cd3c585c0b074c75e2122d70c27c676ee2fadf627f13981"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3cdc68da01e9681dfd1a08d10a6738f7bb9958046386d25f6ce94dc07d119a35"
+    sha256 cellar: :any,                 arm64_sonoma:   "2f05891ca68f1426ddd467af7123c887705613ce7f7b93ba4df0a95f9177f8c4"
+    sha256 cellar: :any,                 arm64_ventura:  "3a6f24b8a5b1b20af38fbc3c28259e22a7ca4568d355c36815012294de97d52a"
+    sha256 cellar: :any,                 arm64_monterey: "33af05a2d3afa44b27d8349e530a33ba9213eb40dd2575339ada69b3c9db94f7"
+    sha256 cellar: :any,                 sonoma:         "b731fe0f0717793955d52ec921f28458192f519b3f77dcae15972953253476e2"
+    sha256 cellar: :any,                 ventura:        "acb05f5ff3b8a7e121c47cdc3fe413d6689032d5b39b2415b6eeb32662f0d63a"
+    sha256 cellar: :any,                 monterey:       "512f4fca3ed3cf0a33251a5f07c312f6f9478bcbab28fc34dbf673265bac23bc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e07a55df23aa198f34998cc4768555200a50ed2e09b68417edd3b3b62ec441f6"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/p/pypy.rb
+++ b/Formula/p/pypy.rb
@@ -1,8 +1,8 @@
 class Pypy < Formula
   desc "Highly performant implementation of Python 2 in Python"
   homepage "https://pypy.org/"
-  url "https://downloads.python.org/pypy/pypy2.7-v7.3.15-src.tar.bz2"
-  sha256 "a66ddaed39544a35bb7ab7a17dbf673a020c7cb3a614bd2b61a54776888daf2c"
+  url "https://downloads.python.org/pypy/pypy2.7-v7.3.16-src.tar.bz2"
+  sha256 "43721cc0c397f0f3560b325c20c70b11f7c76c27910d3df09f8418cec4f9c2ad"
   license "MIT"
   head "https://github.com/pypy/pypy.git", branch: "main"
 

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -14,6 +14,7 @@ class Qt < Formula
     { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } },
     "LGPL-3.0-only",
   ]
+  revision 1
   head "https://code.qt.io/qt/qt5.git", branch: "dev"
 
   # The first-party website doesn't make version information readily available,

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -25,13 +25,13 @@ class Qt < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c87b80d1ef2b6349ada22959c14eae9f5e0bcf0ee3385f888dd1bbe6ecb7d70f"
-    sha256 cellar: :any,                 arm64_ventura:  "38e319f624625d108938ca0ba145bb6f85d8f83855779298d538018ab054ac6c"
-    sha256 cellar: :any,                 arm64_monterey: "6c213a3f53b3489c0e2b5119f33eea3553a76fae1ea561e023a84d565bea067c"
-    sha256 cellar: :any,                 sonoma:         "8537e891808bccd4ea1b273018a29464a9285ed907458498368d93828c097c62"
-    sha256 cellar: :any,                 ventura:        "aa035263156e9fd347ce65c16b5a415928ecefcaebeca9895626a814d4befa31"
-    sha256 cellar: :any,                 monterey:       "51aae7b8dddd0859dd1b26b080ba847713b3d21bd452e127a347995919c1640c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d31639aa9b07a3475673d051e0b847d4a79c90b9858d90a1073b21202579c863"
+    sha256 cellar: :any,                 arm64_sonoma:   "cf3871fc01cfdde43ad7352803291a5b680d05b2f8c2653ab5f79c498a15f1b5"
+    sha256 cellar: :any,                 arm64_ventura:  "d7fa2aac662c9f25e8770b3ab2d5c72802304c46cdd5a8fce8ad93bffa9388b3"
+    sha256 cellar: :any,                 arm64_monterey: "fe6ab103f6afb70dff45c8eccdcf4a47fd1ec95530ea7a2b338990451975578d"
+    sha256 cellar: :any,                 sonoma:         "717760d77542ffaf69199d69ef15de96c711ab088a4528ce51c94d541d233495"
+    sha256 cellar: :any,                 ventura:        "fbe23a62ef1968615988cee985e7aa1e075295132869ebc90efd3e8a5f418863"
+    sha256 cellar: :any,                 monterey:       "bc9a8c39a4dd5c1fd36523ee6109c63881db9b6d438b2eb85949582506ed2af8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "705216c67f0f0c4d712311bfb1ce4dc2cec95aa1094fc6d42596c22f966faa55"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -9,6 +9,7 @@ class QtAT5 < Formula
   mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.13/single/qt-everywhere-opensource-src-5.15.13.tar.xz"
   sha256 "9550ec8fc758d3d8d9090e261329700ddcd712e2dda97e5fcfeabfac22bea2ca"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+  revision 1
 
   livecheck do
     url "https://download.qt.io/official_releases/qt/5.15/"
@@ -322,6 +323,15 @@ class QtAT5 < Formula
       inreplace "qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn",
                 "fatal_linker_warnings = true",
                 "fatal_linker_warnings = false"
+    end
+
+    # Work around Clang failure in bundled Boost and V8:
+    # error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type
+    if DevelopmentTools.clang_build_version >= 1500
+      args << "QMAKE_CXXFLAGS+=-Wno-enum-constexpr-conversion"
+      inreplace "qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn",
+                /^\s*"-Wno-thread-safety-attributes",$/,
+                "\\0 \"-Wno-enum-constexpr-conversion\","
     end
 
     ENV.prepend_path "PATH", Formula["python@3.11"].libexec/"bin"

--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -17,13 +17,13 @@ class QtAT5 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "5a9a0a25576ddda303c27173435ba2a14f71d41947e76ebdfa2c66c5f521559e"
-    sha256 cellar: :any,                 arm64_ventura:  "d52a4992e4cbaec9d9790a63f61dd7b4c923caafa96ed459da2de02a5b393a7c"
-    sha256 cellar: :any,                 arm64_monterey: "92870d85d9cc9a38ccbaeab633bcb93be3c024d9fd82cd27c5c6dc773140a6c4"
-    sha256 cellar: :any,                 sonoma:         "7772f5285c915925b26948e735cb6bd9846e4650a1b1b5859212f9dd8e4dcec3"
-    sha256 cellar: :any,                 ventura:        "95f218168a8a4dc142062fd8fad3106e136be0b24600992015b3599884bc2ae5"
-    sha256 cellar: :any,                 monterey:       "1ef9909c4a419c658470b4b77108182f26f3b45c3ea932718cb33ab0cc980cb3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4f0728d509b474786a20873b9cdc73843c811b8ea8581190e4b5e8fbef211581"
+    sha256 cellar: :any,                 arm64_sonoma:   "3a497f2b6e427f72c52e52e979f655cea54e0d6eddffd1fbf3c4a25bb5eae101"
+    sha256 cellar: :any,                 arm64_ventura:  "a5098835cade678eb6d9193d393c3f7d0cbec5aa4f1833184fba56c13161a097"
+    sha256 cellar: :any,                 arm64_monterey: "02fff8012c9cba1d9a6e79bc500289c79fa1d64b345533b6e5ea5855d322875a"
+    sha256 cellar: :any,                 sonoma:         "5ab138b788d6fa1aeb7f5b1b3c041161efaeb6298771312628a4357fce0dc86f"
+    sha256 cellar: :any,                 ventura:        "2057642d6105bcf0d34c08dc1393be18e41ee36feb5aa48746f7a2d8c7920c28"
+    sha256 cellar: :any,                 monterey:       "f185f54474461f6d408f75a85afb25411b9a06409f2a29b97e3d2e069b7891c9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "792f32f138188fca968478186b361ca74b95770afd8066ee19275616d65a6e00"
   end
 
   keg_only :versioned_formula

--- a/Formula/r/rbtools.rb
+++ b/Formula/r/rbtools.rb
@@ -59,15 +59,9 @@ class Rbtools < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.12")
     # Work around pydiffx needing six pre-installed
     # Upstream PR: https://github.com/beanbaginc/diffx/pull/2
-    pydiffx_resources = %w[setuptools six pydiffx]
-    pydiffx_resources.each do |r|
-      venv.pip_install(resource(r), build_isolation: false)
-    end
-    venv.pip_install resources.reject { |r| pydiffx_resources.include? r.name }
-    venv.pip_install_and_link buildpath
+    virtualenv_install_with_resources end_with: "pydiffx"
 
     bash_completion.install "rbtools/commands/conf/rbt-bash-completion" => "rbt"
     zsh_completion.install "rbtools/commands/conf/_rbt-zsh-completion" => "_rbt"

--- a/Formula/r/redis-leveldb.rb
+++ b/Formula/r/redis-leveldb.rb
@@ -4,7 +4,7 @@ class RedisLeveldb < Formula
   url "https://github.com/KDr2/redis-leveldb/archive/refs/tags/v1.4.tar.gz"
   sha256 "b34365ca5b788c47b116ea8f86a7a409b765440361b6c21a46161a66f631797c"
   license "MIT"
-  revision 3
+  revision 4
   head "https://github.com/KDr2/redis-leveldb.git", branch: "master"
 
   bottle do

--- a/Formula/r/redis-leveldb.rb
+++ b/Formula/r/redis-leveldb.rb
@@ -8,20 +8,13 @@ class RedisLeveldb < Formula
   head "https://github.com/KDr2/redis-leveldb.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "acb624fe50e7f3fc7267f44173ac66ef7f7fed3557d20cb1cfdfd8fe6383ed4e"
-    sha256 cellar: :any,                 arm64_ventura:  "14e20960b64bbccf61906791c432997c805a853eee48593f9d7881490e71d403"
-    sha256 cellar: :any,                 arm64_monterey: "3924d88c6a1080614983fcd3840adeccb78b9cbc0392c62d543edd966c4e9e43"
-    sha256 cellar: :any,                 arm64_big_sur:  "5e41ff1939788e1fa297df8345b1c515b4bdaf046fa7c0d54e853aa1f0030dc1"
-    sha256 cellar: :any,                 sonoma:         "0c5716298ff04f4f79856101aef22240cc7a655eb2ce04c1f8b79b2645e1bb37"
-    sha256 cellar: :any,                 ventura:        "71c8f543584e25088c9d42c8cf0a872fb941ecfba54e0627f0e4eaca7ff9b6e9"
-    sha256 cellar: :any,                 monterey:       "eaf9d161468a86bc6d97e60bec55862eaee573b526c290de859e48cf1dbe5248"
-    sha256 cellar: :any,                 big_sur:        "ca866ff83813a3d7a06626608016aba38a40bd1e813f04079dd2221f5740336b"
-    sha256 cellar: :any,                 catalina:       "d1c4da1f1f3e3afec9ec5d345743f9d49e85615fa3ffde619bad13e479ce670a"
-    sha256 cellar: :any,                 mojave:         "f2345f0e55d37343c3c7e2fb4c43e517d429db2bb284430d3db1222675b8b520"
-    sha256 cellar: :any,                 high_sierra:    "9efe9023206565f3d5557202465fa99440262aef2298894c1f738dba0a39ad10"
-    sha256 cellar: :any,                 sierra:         "c8cdcf2f80de6eda4f86e9a7c6726ef1a2e046378a28b72b52deb180a15d1916"
-    sha256 cellar: :any,                 el_capitan:     "5373414613caf193828f782883f835858a8c999943a542e9ec3ff735a918bb63"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1723583af723d8a9d13f45b476071b70bac6c509f96e9ffba3d975f45ca4e521"
+    sha256 cellar: :any,                 arm64_sonoma:   "2c4f724a8e484fe6949b3733a7c1d4201370dabbbbd3b5e4a7e4b4312a06bba7"
+    sha256 cellar: :any,                 arm64_ventura:  "8ed6a3bbc7dcfb695d7d133bb5f87eb564288e0f1ab221099449b1dd4f8bbabe"
+    sha256 cellar: :any,                 arm64_monterey: "6ae884a362ca96df3f67994461b0732d305e7dba323598dba029338a11d10cf3"
+    sha256 cellar: :any,                 sonoma:         "edac4282df53a53882efe10586ee1d39c06b3f03f150d128f6acfa115c039cf8"
+    sha256 cellar: :any,                 ventura:        "8eec3d30dde80b6f32de4c1167cad93bc2c6b95e9c7c65b017320e487b19975d"
+    sha256 cellar: :any,                 monterey:       "385b411fac0e4374c3b61f952e09f0266a9a13a23bb12c91cb1209ff99547012"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6323dd8c468b9cc40d9310fdeb776de380e1c32c622e682713dd98a9cf42e659"
   end
 
   depends_on "gmp"

--- a/Formula/r/renovate.rb
+++ b/Formula/r/renovate.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Renovate < Formula
   desc "Automated dependency updates. Flexible so you don't need to be"
   homepage "https://github.com/renovatebot/renovate"
-  url "https://registry.npmjs.org/renovate/-/renovate-37.320.0.tgz"
-  sha256 "3a559bcc497839e25baa188cfbc8f726bbba068c8d27e4e9aa58f2e31ff98959"
+  url "https://registry.npmjs.org/renovate/-/renovate-37.321.0.tgz"
+  sha256 "67d95c08cfb0a51ab5a1916f2b1bb5e36caf617b7b967e6cd002d380acba2e1c"
   license "AGPL-3.0-only"
 
   # There are thousands of renovate releases on npm and the page the `Npm`

--- a/Formula/r/renovate.rb
+++ b/Formula/r/renovate.rb
@@ -19,13 +19,13 @@ class Renovate < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "895d74e5082f4062017d3b5247164b5c18ab71949e14c927116d63950fb00cb0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c0c6ac14a34d76dceb01a536b74e340a884c69011bdee2b441454df1afa8f70d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "99c5a54cd5f23ed9b81b7614cb415d2f7af455a14d2e329330520a3de2d4ca35"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ad522d392e4e8cf4d8755e4dd481c786a5ebfc1a83dbaed56ef31aca386eac49"
-    sha256 cellar: :any_skip_relocation, ventura:        "b89364e566be968401583882c3722183f20ea622e90e0275e983fc063d829d5e"
-    sha256 cellar: :any_skip_relocation, monterey:       "ec4730aba375b38c5f719e1435ba06708f147b3ba93282b3f2da2f0af5f65191"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bc6851de8332c6aabfc361c1a482be96258b7700301eca247802f4952c5674d4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9c17eb3f995d1cef2afa514d3189c01f337e9e992b22f713997ba284784f2ee8"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "36f368f21b0f9e0bfd84caddd48aadf003882eaa97afd66d6da0524463149c05"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6af9951714ec3526a6c91fc8f5a09aa448acdfea294de987a2d12457370b1030"
+    sha256 cellar: :any_skip_relocation, sonoma:         "75d3a317674a3aaf30cf7c39c154bd1f0aed5c1a9bf547065a96eebdf04b4822"
+    sha256 cellar: :any_skip_relocation, ventura:        "a08941759c5d97cfb4dc884110fe18c31888da66ad0db4afa483fbcc62169341"
+    sha256 cellar: :any_skip_relocation, monterey:       "2e87747c39ea2b8a2b81e1d20bd06b4d9630df412781d028d077e47053561642"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "46a499d6211061fed99ed668be7a434280bcd1d8fce516919f2504cddd44b536"
   end
 
   depends_on "node"

--- a/Formula/r/rocksdb.rb
+++ b/Formula/r/rocksdb.rb
@@ -4,6 +4,7 @@ class Rocksdb < Formula
   url "https://github.com/facebook/rocksdb/archive/refs/tags/v9.1.1.tar.gz"
   sha256 "54ca90dd782a988cd3ebc3e0e9ba9b4efd563d7eb78c5e690c2403f1b7d4a87a"
   license any_of: ["GPL-2.0-only", "Apache-2.0"]
+  revision 1
   head "https://github.com/facebook/rocksdb.git", branch: "main"
 
   bottle do

--- a/Formula/r/rocksdb.rb
+++ b/Formula/r/rocksdb.rb
@@ -8,13 +8,13 @@ class Rocksdb < Formula
   head "https://github.com/facebook/rocksdb.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "0e351224f85d7395607446df6ab6090980cc361876fef0bebc8616d7bb58fde0"
-    sha256 cellar: :any,                 arm64_ventura:  "928e66cada899a01081204ae43863c9a692a5ddccb15c80cb9012dfa2178b7f4"
-    sha256 cellar: :any,                 arm64_monterey: "4ba6eb79ee4a5143ff0f188bfaa59e821789b725033f0bf5d0575293de4a4fff"
-    sha256 cellar: :any,                 sonoma:         "1f0cb75a9246dda6ae0885708044a1229ef4b2631aca3da2af4d9dd9eeca321b"
-    sha256 cellar: :any,                 ventura:        "291b196a6c27620c5a50205db8b1e951b8ee5c5d0a8f378dc6a7eeec159075c7"
-    sha256 cellar: :any,                 monterey:       "70677c48cc4bf6dfe1803ca172a5ac41998839a5346d3de7dd127ea6a029206f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "216e160255944c553d98fb04a373d35c5e4d73c57900cb43d30a2631b0a9cecb"
+    sha256 cellar: :any,                 arm64_sonoma:   "9cf792c71d5c89990ecc04b853d36a4fb78856ef08d1fb5a205796f6ce1d2daa"
+    sha256 cellar: :any,                 arm64_ventura:  "414e895ec0455abb37149355a425224193202b74d63d3ce2758d92eb69f27986"
+    sha256 cellar: :any,                 arm64_monterey: "4e1093c9ff3e892aad8fda3bcdda81bba2195b851a0b6188a1f9caaf555d4aeb"
+    sha256 cellar: :any,                 sonoma:         "0f7f4a51dae7797df6a23e3cfef9bae27d4767dbeed16a5a8bc1ff45bd8587e3"
+    sha256 cellar: :any,                 ventura:        "aa96dd77b80b8ee7e2d70da1580d951893dae3ec52383c5772359167aadb809b"
+    sha256 cellar: :any,                 monterey:       "d4b042f5e323a9671f2b0364bdfb5a51596458d44551b888243db238b90a179e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8ab6e0636dc5e7beaec5d5f93d078a9bdf7abcca9a619e777a911caf03eec4cc"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/semgrep.rb
+++ b/Formula/s/semgrep.rb
@@ -37,6 +37,7 @@ class Semgrep < Formula
   depends_on "gmp"
   depends_on "libev"
   depends_on "pcre"
+  depends_on "pcre2"
   depends_on "python@3.11" # Python 3.12 blocked by imp usage in glom < 23.4.0
   depends_on "sqlite"
   depends_on "tree-sitter"
@@ -202,6 +203,8 @@ class Semgrep < Formula
       ENV["OPAMYES"] = "1"
       # Set library path so opam + lwt can find libev
       ENV["LIBRARY_PATH"] = "#{HOMEBREW_PREFIX}/lib"
+      # Set path to libev for our static linking logic
+      ENV["SEMGREP_LIBEV_ARCHIVE_PATH"] = "#{HOMEBREW_PREFIX}/lib/libev.a"
 
       system "opam", "init", "--no-setup", "--disable-sandboxing"
       ENV.deparallelize { system "opam", "switch", "create", "ocaml-base-compiler.4.14.0" }

--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -1,8 +1,8 @@
 class Snappy < Formula
   desc "Compression/decompression library aiming for high speed"
   homepage "https://google.github.io/snappy/"
-  url "https://github.com/google/snappy/archive/refs/tags/1.1.10.tar.gz"
-  sha256 "49d831bffcc5f3d01482340fe5af59852ca2fe76c3e05df0e67203ebbe0f1d90"
+  url "https://github.com/google/snappy/archive/refs/tags/1.2.0.tar.gz"
+  sha256 "9b8f10fbb5e3bc112f2e5e64f813cb73faea42ec9c533a5023b5ae08aedef42e"
   license "BSD-3-Clause"
   head "https://github.com/google/snappy.git", branch: "master"
 

--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -7,15 +7,13 @@ class Snappy < Formula
   head "https://github.com/google/snappy.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "dbe6bca5814b986d91bf204c4b59df8a411b2654eafa53d058e6ff973c4e2451"
-    sha256 cellar: :any,                 arm64_ventura:  "ca95915a51bed09a5e70ebb6f253eabe4df5b00e87ebe49aea0124f8bb51bc3c"
-    sha256 cellar: :any,                 arm64_monterey: "40cfa23024bcadc5ed04823eb8dea4595ebe8e793d913e3c0074defb8eb9e185"
-    sha256 cellar: :any,                 arm64_big_sur:  "a18f25dc10ceffe4f8f0256c6ed9354e22a70069f01fc27013cee8cd7238386d"
-    sha256 cellar: :any,                 sonoma:         "b97a0a65ebf2af67f4800e31325908d1aeedafd9e28796ae95fc051d44ec10cd"
-    sha256 cellar: :any,                 ventura:        "1e9238c5f3f100b635ca74a17b3441d5f5f9c23007537107340d5397bcbd483d"
-    sha256 cellar: :any,                 monterey:       "6c0e72f9f601374a7bfe92a9083e382715dc885015c36fc9081de0c068c5fd33"
-    sha256 cellar: :any,                 big_sur:        "14d183eff56f11c0ffdc1394d1fedfaa3cc5ba315e3abe4c21598dfbe9fe25d1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "73aa76de40ad1ca4f5b03a76180a018aadbc05bda2cde1d4b9030cf56d100f2f"
+    sha256 cellar: :any,                 arm64_sonoma:   "4a20c424a6cab88e165030ce17f347cfcbf27c32b3ef4f03c5622b054510b4a2"
+    sha256 cellar: :any,                 arm64_ventura:  "c8bd2d0f2c8812acabf1054836f36b65f05bc423967eea60e2eb0227ebc02d81"
+    sha256 cellar: :any,                 arm64_monterey: "c2c8cde9635ba55b3b0f6cb8994b07d157166926fc809bfe5b2d8664898ca84b"
+    sha256 cellar: :any,                 sonoma:         "d5541a4d0489d0fb44cd2777c15b3dc0a9e8645cad4756e48dafcf076ce03f84"
+    sha256 cellar: :any,                 ventura:        "51b567229c4139ff3cab524055cb8c40e53a63d1d8fe2267916f0ffa61bcd0ed"
+    sha256 cellar: :any,                 monterey:       "bf3865f380331ba25729c5856caac0668fcc242e70b4ac768b713ea68018f8ab"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ae12c0660f75dd132bc44df65b8ee38152f1dae9f616589ae4ca95a2b46eae7"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/snappystream.rb
+++ b/Formula/s/snappystream.rb
@@ -4,6 +4,7 @@ class Snappystream < Formula
   url "https://github.com/hoxnox/snappystream/archive/refs/tags/1.0.0.tar.gz"
   sha256 "a50a1765eac1999bf42d0afd46d8704e8c4040b6e6c05dcfdffae6dcd5c6c6b8"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/hoxnox/snappystream.git", branch: "master"
 
   bottle do
@@ -51,8 +52,8 @@ class Snappystream < Formula
       }
     EOS
     system ENV.cxx, "test.cxx", "-o", "test",
-                    "-L#{Formula["snappy"].opt_lib}", "-lsnappy",
-                    "-L#{lib}", "-lsnappystream"
+                    "-L#{lib}", "-lsnappystream",
+                    "-L#{Formula["snappy"].opt_lib}", "-lsnappy"
     system "./test < #{__FILE__} > out.dat && diff #{__FILE__} out.dat"
   end
 end

--- a/Formula/s/snappystream.rb
+++ b/Formula/s/snappystream.rb
@@ -8,17 +8,13 @@ class Snappystream < Formula
   head "https://github.com/hoxnox/snappystream.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8c1c594c5ebf0ae7e7341f7fb3cf380546b397dcc3755bf784e5b6061341646a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6f548979a18dc5f812f008e189bcc86ce1db4d12297eed756f70f2cebb0ad8db"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4f0621fed569c3f1f467fb5b89a1727d02dd9f069eac22dd662750764a34ad40"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4723ca8cfbd115326740f631b84db163cba902c1233c98e0b413a4250c228692"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9f50710b7ea9951c7c3e4a7c17ad090a4219e7527148997c96fa126eb70933e2"
-    sha256 cellar: :any_skip_relocation, ventura:        "95271f76e12095cab04b34d0fc977a63ebae368837061cd034be543d1eed6733"
-    sha256 cellar: :any_skip_relocation, monterey:       "1c5ef41496ec66bddc4e850801c848886a096637917b178b5486f7b04e246fe3"
-    sha256 cellar: :any_skip_relocation, big_sur:        "0259933ab01a0edf8162f901820728e9f36e0244e6dc34aa8de64caf95247bcb"
-    sha256 cellar: :any_skip_relocation, catalina:       "083a4297326a9171920d68c6f0d93891d1cef8971546efd0293360b8dfc4e564"
-    sha256 cellar: :any_skip_relocation, mojave:         "f768ccd06fd8d1cceb9905d71d7be38b55c3d2797df8d58a4f5528f22144db6d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4647e986c27d16e41d5636d0d14b096f09a69e446e6cebf2715e2de88c579527"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b3e452bf6ee2fb64d89388ac99d1786218bad625c6fc71f0cb4284f57bf150c7"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9c92c2f15283870584d9fe49062734d66b6c1db1f10bf018249c3a7cd0f9110f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6e0352aaa68c6373355d22f3aa92fb056077439b26869bd317076176aea7bcab"
+    sha256 cellar: :any_skip_relocation, ventura:        "87329a4191cefc04c19ae16543101a5d94336812ede1047c34e52db7ff2a4006"
+    sha256 cellar: :any_skip_relocation, monterey:       "0d58d7dd0573099e572969f5d38c821317171db8de851d0c5d7eb56d46ac54ad"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5689e64e2ccf991d92a2adff2eef8b2ac32490467ce64bc09e93cee407b60d8a"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/ssh-mitm.rb
+++ b/Formula/s/ssh-mitm.rb
@@ -3,6 +3,7 @@ class SshMitm < Formula
 
   desc "SSH server for security audits and malware analysis"
   homepage "https://docs.ssh-mitm.at"
+  # TODO: Remove `setuptools` from pypi_formula_mappings.json in the next release.
   url "https://files.pythonhosted.org/packages/dc/15/b3b4189bcd5ba6a86e65d72689a980eb66a67a4a6bccdc1639b9251cd29a/ssh_mitm-4.1.1.tar.gz"
   sha256 "db61c3d33e4515bde82118e9f62dd3d25dbf35718005af16b30316dfa0be7b4f"
   license "GPL-3.0-only"
@@ -115,11 +116,7 @@ class SshMitm < Formula
   end
 
   def install
-    # Multiple resources require `setuptools`, so it must be installed first
-    venv = virtualenv_create(libexec, "python3.12")
-    venv.pip_install resource("setuptools")
-    venv.pip_install resources.reject { |r| r.name == "setuptools" }
-    venv.pip_install_and_link buildpath
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/t/terragrunt.rb
+++ b/Formula/t/terragrunt.rb
@@ -6,13 +6,13 @@ class Terragrunt < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5b65cd920d9262e132b7c0b751d2965a5e1d7173248bb00410bce58f90ad2443"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "42e6115d37f2f1ba6eb8d7ede81eeb37cbf1fdc84465fe4c3146a2cb5144575c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "62b95adf4ccd282cdb4ad88bd92baf04c6cc10d16132f69753a24af5b0cb4af2"
-    sha256 cellar: :any_skip_relocation, sonoma:         "3e897f3b4b62831f5791c9b63d459017f6096d7b61c06a1b0e301a071e7bf8b6"
-    sha256 cellar: :any_skip_relocation, ventura:        "30536ea493f24d1202122fa234fb82423e8facfd1365cb551a208142acedd9ac"
-    sha256 cellar: :any_skip_relocation, monterey:       "2cd0e73d1f267e41cf5713e9e2e447327897687d3e0f216bec65d828ccd6ba28"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cc25fd4a9cae4bb509dedaed268562dd705c6e8447feffca5bb9721f53faf814"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "10425eb8a42a2c87ba1cb315e1cd5e37ef6f13c6bf972ce61f54d940a7995c0b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9601de2e8e1ce7336c00cf1e9d7a015eb5470b7a916cf29a233a9d76acbb585f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b181f0afbcdaed9a54725022770df3f9a8eec95c34c0e047c56b28c5bb529646"
+    sha256 cellar: :any_skip_relocation, sonoma:         "53ab568b1b9208d23ae01a71898081a464c385785f089d5e4df4566dedc48089"
+    sha256 cellar: :any_skip_relocation, ventura:        "b3d85a406479c0f091d2691c73aa4276fe3fc7aee783594ecb9f332061e6708e"
+    sha256 cellar: :any_skip_relocation, monterey:       "40caad8939f56eb79cf259c743a6735e74a13670446ac309470fdcda796d5e18"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c461740c12af784533fb3d9e9862596919fe01651710e00195b4a5a611141e2c"
   end
 
   depends_on "go" => :build

--- a/Formula/t/terragrunt.rb
+++ b/Formula/t/terragrunt.rb
@@ -1,8 +1,8 @@
 class Terragrunt < Formula
   desc "Thin wrapper for Terraform e.g. for locking state"
   homepage "https://terragrunt.gruntwork.io/"
-  url "https://github.com/gruntwork-io/terragrunt/archive/refs/tags/v0.57.8.tar.gz"
-  sha256 "d625f3899bfe381731c3209e8fa8e6304acda45b0fe1acceae242d07800cb560"
+  url "https://github.com/gruntwork-io/terragrunt/archive/refs/tags/v0.57.9.tar.gz"
+  sha256 "69545ec71b15f84b636c2a4b5daa19ff268ce36f5adcd23387d5e9d038dadcee"
   license "MIT"
 
   bottle do

--- a/Formula/v/verapdf.rb
+++ b/Formula/v/verapdf.rb
@@ -12,13 +12,13 @@ class Verapdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "210bac514d2e765ea4314114a9d5790209efc4774b3924b524b993ba56e2941f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "08b1ddf518ca89999ae84c2498661f2751868638d7cce5f4ad226fbcd9011141"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "86612d4d03e9e6fa7b265d89c1661c87cc903131be38b949589d07779da988a0"
-    sha256 cellar: :any_skip_relocation, sonoma:         "2119124975c991cf6c2bfb672f9eebbfc534fb7388b44aa03c4ae9c44c4059d6"
-    sha256 cellar: :any_skip_relocation, ventura:        "529431260623809450f9f4665db7cfb3772004956179d28427dc910197e5dd35"
-    sha256 cellar: :any_skip_relocation, monterey:       "43fd9757506da07af145de171a8b5979a883f389a9db1473d809a794ac5afdfa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "968ad93c91186ce2b75775d97fa5a4b1cbfc17baa7ba68bb89647c1aeb592903"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b92aae2e943867909218a0ab54fa9a0dd59e0451b07c26dd832b51b9a1f5e2e7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a3a0e267f5b459761da56a50cd50d0f87bee48c78ea2270ef8bce69ebd078dab"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b380eda903dbb8f7fe444456da208da0fe3a56a7ed477c3c02860a753fa4b2c0"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1fa9c796c11943557aefb5918f01f8f86c5f8620c2eafe03ff0eb871753a2663"
+    sha256 cellar: :any_skip_relocation, ventura:        "64fdabdb952c071dd1c27ec945c1a081172ca38ffe6ed059410f4f53b1a51266"
+    sha256 cellar: :any_skip_relocation, monterey:       "b703cf8031a1ad70a4c6cee422665c0eaa973a95691f77be4b1b020bfb2b0ddd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "737033d8cf16198aaf40b4cafbd3e290ff7ae5461f3fdebd1db9e10bba11fa2b"
   end
 
   depends_on "maven" => :build

--- a/Formula/v/verapdf.rb
+++ b/Formula/v/verapdf.rb
@@ -1,8 +1,8 @@
 class Verapdf < Formula
   desc "Open-source industry-supported PDF/A validation"
   homepage "https://verapdf.org/home/"
-  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.25.250.tar.gz"
-  sha256 "988d7b455a5bfb2ef91f6f9986ae54a1a9f99553148403c81619de7a3755b0a8"
+  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.25.251.tar.gz"
+  sha256 "8a4f2559de6aa6a214502582330a38f0f9033679d012a824c0d4d243e9204140"
   license any_of: ["GPL-3.0-or-later", "MPL-2.0"]
   head "https://github.com/veraPDF/veraPDF-apps.git", branch: "integration"
 

--- a/Formula/v/vercel-cli.rb
+++ b/Formula/v/vercel-cli.rb
@@ -8,13 +8,13 @@ class VercelCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bcb7800b1abb647b7638c62bd05831f5bb15ef1e981b801800be04f34c20d4d7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bcb7800b1abb647b7638c62bd05831f5bb15ef1e981b801800be04f34c20d4d7"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "bcb7800b1abb647b7638c62bd05831f5bb15ef1e981b801800be04f34c20d4d7"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d01f72eec78218d5a07379e7cba8f15cfa97d1d7be74f5d1c921ba06e4ef2491"
-    sha256 cellar: :any_skip_relocation, ventura:        "d01f72eec78218d5a07379e7cba8f15cfa97d1d7be74f5d1c921ba06e4ef2491"
-    sha256 cellar: :any_skip_relocation, monterey:       "d01f72eec78218d5a07379e7cba8f15cfa97d1d7be74f5d1c921ba06e4ef2491"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "afd77e67658886078275d8db313e3a9332d546c77966a4ee8ac8eb1d19c3150b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cfe80d01d2ef027ea164d0f32d3adb909986163e88557199ddd5c81ecefdde20"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cfe80d01d2ef027ea164d0f32d3adb909986163e88557199ddd5c81ecefdde20"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "cfe80d01d2ef027ea164d0f32d3adb909986163e88557199ddd5c81ecefdde20"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d95e4a90717b9c5edca6ae9aacab99047a5276bfd6f3bcbcf28b569acf91fb14"
+    sha256 cellar: :any_skip_relocation, ventura:        "d95e4a90717b9c5edca6ae9aacab99047a5276bfd6f3bcbcf28b569acf91fb14"
+    sha256 cellar: :any_skip_relocation, monterey:       "d95e4a90717b9c5edca6ae9aacab99047a5276bfd6f3bcbcf28b569acf91fb14"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "86c77bef4f22f6161208d5c0ca0ec46daea88c01d2daa3b780a7dbcd75b9113d"
   end
 
   depends_on "node"

--- a/Formula/v/vercel-cli.rb
+++ b/Formula/v/vercel-cli.rb
@@ -3,8 +3,8 @@ require "language/node"
 class VercelCli < Formula
   desc "Command-line interface for Vercel"
   homepage "https://vercel.com/home"
-  url "https://registry.npmjs.org/vercel/-/vercel-34.1.1.tgz"
-  sha256 "266c3dd6b94ba0ae8c4d349b45261c3ab64ff9db3b650ad344fcdf4062f7ea42"
+  url "https://registry.npmjs.org/vercel/-/vercel-34.1.2.tgz"
+  sha256 "67d2fbe48197b47cce41a40b0086045a42c7ac500a1ba0abfda6527cd720ebcb"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/w/werf.rb
+++ b/Formula/w/werf.rb
@@ -1,8 +1,8 @@
 class Werf < Formula
   desc "Consistent delivery tool for Kubernetes"
   homepage "https://werf.io/"
-  url "https://github.com/werf/werf/archive/refs/tags/v1.2.307.tar.gz"
-  sha256 "025f21d41af247bff027cfde3034e564774d78b8b4191651ee6c561c40a37d89"
+  url "https://github.com/werf/werf/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "7373fa3d1dfdbe352ffeefbddbd9006e0396b2f0b35ed7b921044d9379430ce6"
   license "Apache-2.0"
   head "https://github.com/werf/werf.git", branch: "main"
 
@@ -38,14 +38,14 @@ class Werf < Formula
         -linkmode external
         -extldflags=-static
         -s -w
-        -X github.com/werf/werf/pkg/werf.Version=#{version}
+        -X github.com/werf/werf/v2/pkg/werf.Version=#{version}
       ]
       tags = %w[
         dfrunsecurity dfrunnetwork dfrunmount dfssh containers_image_openpgp
         osusergo exclude_graphdriver_devicemapper netgo no_devmapper static_build
       ].join(" ")
     else
-      ldflags = "-s -w -X github.com/werf/werf/pkg/werf.Version=#{version}"
+      ldflags = "-s -w -X github.com/werf/werf/v2/pkg/werf.Version=#{version}"
       tags = "dfrunsecurity dfrunnetwork dfrunmount dfssh containers_image_openpgp"
     end
 

--- a/Formula/w/werf.rb
+++ b/Formula/w/werf.rb
@@ -15,13 +15,13 @@ class Werf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5a080f2303fd9471471c4729de3e775f4efe7c618abaf35fa433b79fe40ad61c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e5d8a150f00d3a519519fdd8b5944eb86c1dc1286cc2fabb6b6969cbfe9d5783"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9e2389fde0925fe296fb6c37f63fefee63907f4ab8d29177c8c34430ec946099"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c522af6e6579fb7befc6da4bb233ef183c9908d8d59baf31ffbdb15bbc89f6a0"
-    sha256 cellar: :any_skip_relocation, ventura:        "9f26b5b1d25f3b07010a4e8f0298a69a829232f8481e50bfd1b2524b228c85b1"
-    sha256 cellar: :any_skip_relocation, monterey:       "8478d4f65519156a3a817b98cf4c99b57420639b21eb2d4eb208516ffdfa913a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "de3ee0728c17d98b768ffb558d5d4c010a76b55a853b714810e64e306d26ff53"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c8d6c205feeb74f7b999bad5a2851a3ca054ff249b26fec2a6f482995070f572"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b6030608074def31ddfae122197b983840532ba5cd9b7ae05b791555dcc4836a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6c8489b372e9b04d6333e4e382cf7508bfc0798d0e92ba8f0790480f469950d5"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6b179cab27bef107616007ec9d692eaf8f4648530cf24b109194f51dc915f028"
+    sha256 cellar: :any_skip_relocation, ventura:        "225f29bfd6a1980e1ac12b8142fb88e43f01ad03353870454baa5a9fb58dc5c3"
+    sha256 cellar: :any_skip_relocation, monterey:       "f2f3afd43d1bcbf4fedc34eeab30465f7a88cb2f7699cd6a76765b27e79b5959"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "715db81b92c012a488a262089847b723d17a636f547b137892860383603f3e79"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Semgrep changed how static linking on Mac is done. This works well now for all packages except libev, which doesn't support pkg-config. To link libev when building with brew, we need to provide the path to libev.

Test plan: in addition to the below we need to specifically run (in the semgrep repo)
```
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source path/to/homebrew-core/Formula/s/semgrep.rb --debug --HEAD 
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
